### PR TITLE
MOS-1852: Fix pattern construction to preserve actions after filters

### DIFF
--- a/src/main/java/org/cqfn/astranaut/core/algorithms/SubtreeBuilder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/SubtreeBuilder.java
@@ -43,13 +43,14 @@ public class SubtreeBuilder {
     /**
      * Algorithm that composes a subtree only from the nodes that are specified in the set.
      */
-    public static final Algorithm INCLUDE = (node, set) -> set.contains(node);
+    public static final Algorithm INCLUDE = SubtreeBuilder::isPresentInSet;
 
     /**
      * Algorithm that composes a subtree from all nodes in the original tree,
      *  but excludes nodes specified in the set.
      */
-    public static final Algorithm EXCLUDE = (node, set) -> !set.contains(node);
+    public static final Algorithm EXCLUDE =
+        (node, set) -> !SubtreeBuilder.isPresentInSet(node, set);
 
     /**
      * The root node of the original tree.
@@ -116,6 +117,20 @@ public class SubtreeBuilder {
                 this.build(child, indexes, set);
             }
         }
+    }
+
+    /**
+     * Checks whether a node or its prototype is present in the node set.
+     * @param node Node to be checked
+     * @param set Set of nodes
+     * @return Checking result.
+     */
+    private static boolean isPresentInSet(final Node node, final Set<Node> set) {
+        boolean result = set.contains(node);
+        if (!result && node instanceof PrototypeBasedNode) {
+            result = SubtreeBuilder.isPresentInSet(((PrototypeBasedNode) node).getPrototype(), set);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/cqfn/astranaut/core/base/PatternNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/PatternNode.java
@@ -125,14 +125,11 @@ public final class PatternNode extends NodeAndType implements PatternItem, Proto
         final List<PatternItem> result = new ArrayList<>(count);
         for (int index = 0; index < count; index = index + 1) {
             final Node child = original.getChild(index);
-            if (child instanceof DiffNode) {
-                result.add(
-                    new PatternNode(((DiffNode) child).getPrototype())
-                );
-            } else if (child instanceof Action) {
-                result.add((PatternItem) child);
-            } else {
+            final Action action = Action.toAction(child);
+            if (action == null) {
                 result.add(new PatternNode(child));
+            } else {
+                result.add(action);
             }
         }
         return result;


### PR DESCRIPTION
Cool Story:
In the core of the project, we use three main entities: the syntax tree (Tree), the differential tree (DiffTree, inherited from Tree), and the pattern (Pattern, inherited from Tree). Essentially, the pattern is a differential tree with holes, and the differential tree is just a regular tree with actions. The expected flow is: first, we obtain a pair of "regular" trees from the parser, then build a differential tree from them, and finally perforate the differential tree to create a pattern.

This setup worked well until we started applying filters to the differential tree before perforation. The filters involve extracting subtrees from the original differential tree, and potentially extracting subtrees from these subtrees multiple times. The problem arises because the subtree node is not technically a node of the differential tree; it's a SubtreeNode object. In other words, the Action object is replaced by a SubtreeNode, which contains an Action object. In some cases, this nesting level increases (a SubtreeNode contains another SubtreeNode, which contains an Action), causing us to lose actions when constructing the pattern. The result is a pattern with holes but no actions. This is a bug.

To fix this, we need to properly build the pattern, taking into account that an Action can, in some cases, be a prototype of a PrototypeBasedNode.

Task:
Correct the pattern construction process to ensure that actions are preserved even after applying filters to the differential tree. Specifically, when building the pattern, we need to account for the possibility that an Action might be a prototype of a PrototypeBasedNode.