### PR TITLE
MOS-1864: Fix partial pattern application in matcher

### DIFF
--- a/src/main/java/org/cqfn/astranaut/core/base/ActionList.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/ActionList.java
@@ -23,8 +23,10 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -33,14 +35,13 @@ import org.cqfn.astranaut.core.utils.Promise;
 
 /**
  * List of actions to be added to the tree after deserialization to produce a difference tree.
- *
  * @since 1.1.0
  */
 public final class ActionList {
     /**
      * Collection of nodes to be inserted.
      */
-    private final Set<Insertion> insert;
+    private final List<Insertion> insert;
 
     /**
      * Collection of nodes to be replaced (node before changes -> node after changes).
@@ -56,7 +57,7 @@ public final class ActionList {
      * Constructor.
      */
     public ActionList() {
-        this.insert = new HashSet<>();
+        this.insert = new ArrayList<>(0);
         this.replace = new HashMap<>();
         this.delete = new HashSet<>();
     }
@@ -107,6 +108,16 @@ public final class ActionList {
      */
     public void deleteNode(final Node node) {
         this.delete.add(node);
+    }
+
+    /**
+     * Adds actions from another list to the current list.
+     * @param other Another action list
+     */
+    public void merge(final ActionList other) {
+        this.insert.addAll(other.insert);
+        this.replace.putAll(other.replace);
+        this.delete.addAll(other.delete);
     }
 
     /**


### PR DESCRIPTION
Cool Story:
Even if the pattern itself is correct, it may be applied incorrectly if it is partially matched in some cases. During pattern application, the matcher collects the actions that need to be executed. If the pattern cannot be fully applied to a subtree, but there's a partial match, the list of actions may still include actions that were found before it became clear that the pattern couldn't be applied. These actions will remain in the list and be executed, leading to an incorrect final tree. This is a bug.

Task:
Fix the matcher to ensure that when a pattern is only partially applicable, no actions are executed that were collected prior to determining that the pattern cannot be fully applied. This will prevent incorrect actions from being included in the final execution.