### PR TITLE
MOS-1971: Fix incorrect merging of subpatterns during insertion

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 Ivan Kniazkov
+Copyright (c) 2025 Ivan Kniazkov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2024 Ivan Kniazkov
+Copyright (c) 2025 Ivan Kniazkov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -134,7 +134,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.kniazkov</groupId>
       <artifactId>json</artifactId>
-      <version>1.1</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>guru.nidi</groupId>

--- a/src/main/java/org/cqfn/astranaut/core/Info.java
+++ b/src/main/java/org/cqfn/astranaut/core/Info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/DepthCalculator.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/DepthCalculator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/DepthCalculator.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/DepthCalculator.java
@@ -29,7 +29,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Algorithm for measuring the depth of syntax trees.
- *
  * @since 1.1.0
  */
 public final class DepthCalculator {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/DepthFirstWalker.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/DepthFirstWalker.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/DepthFirstWalker.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/DepthFirstWalker.java
@@ -30,7 +30,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Performs a depth-first traversal of the syntax tree.
- *
  * @since 1.1.5
  */
 public class DepthFirstWalker {
@@ -49,11 +48,11 @@ public class DepthFirstWalker {
 
     /**
      * Processes nodes starting from the root. Processes a node first.
-     * If the stopping criterion is not reached, recursively processes all children of it,
-     * starting from the first one. Once a node is found that satisfies the criterion,
-     * stops traversal.<br/>
-     * And yes, you can use this algorithm not only to find nodes, but also just to traverse
-     * the tree in the specific order.
+     *  If the stopping criterion is not reached, recursively processes all children of it,
+     *  starting from the first one. Once a node is found that satisfies the criterion,
+     *  stops traversal.<br/>
+     *  And yes, you can use this algorithm not only to find nodes, but also just to traverse
+     *  the tree in the specific order.
      * @param visitor Visitor that processes nodes
      * @return Found node (optional)
      */
@@ -63,8 +62,8 @@ public class DepthFirstWalker {
 
     /**
      * Processes nodes starting from the root.
-     * If a node matches the criterion, adds it to the set and does not check
-     * the children of this node, otherwise it does.
+     *  If a node matches the criterion, adds it to the set and does not check
+     *  the children of this node, otherwise it does.
      * @param visitor Visitor that processes nodes
      * @return List of found nodes (can be empty, but not {@code null})
      */
@@ -137,7 +136,6 @@ public class DepthFirstWalker {
 
     /**
      * Payload interface for the traversal algorithm.
-     *
      * @since 1.1.5
      */
     public interface Visitor {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/DiffTreeBuilder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/DiffTreeBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/DiffTreeBuilder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/DiffTreeBuilder.java
@@ -36,7 +36,6 @@ import org.cqfn.astranaut.core.base.Tree;
 
 /**
  * Builder of difference syntax tree, that is, one that stores changes between two trees.
- *
  * @since 1.1.5
  */
 public final class DiffTreeBuilder {
@@ -107,7 +106,7 @@ public final class DiffTreeBuilder {
 
     /**
      * Adds an action to the difference tree that inserts a node after another node.
-     * If no other node is specified, inserts at the beginning of the children's list.
+     *  If no other node is specified, inserts at the beginning of the children's list.
      * @param insertion Full information about the node being inserted
      * @return Result of operation, {@code true} if action was added
      */
@@ -208,7 +207,6 @@ public final class DiffTreeBuilder {
 
     /**
      * Some additional information about each node needed to insert, replace, or delete nodes.
-     *
      * @since 1.1.0
      */
     private static final class NodeInfo {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/ExtNodeCreator.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/ExtNodeCreator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/IdenticalNodeFinder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/IdenticalNodeFinder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/IdenticalNodeFinder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/IdenticalNodeFinder.java
@@ -66,8 +66,7 @@ public class IdenticalNodeFinder {
 
     /**
      * Calculates hash recursively for all nodes with non-empty data and
-     * adds entries to the resulting map.
-     *
+     *  adds entries to the resulting map.
      * @param node The current node to process
      * @param result Where to put the result
      */

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/LabeledTreeBuilder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/LabeledTreeBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/NodeAllocator.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/NodeAllocator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/NodeAllocator.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/NodeAllocator.java
@@ -81,7 +81,7 @@ public class NodeAllocator {
 
     /**
      * Maps the list of nodes by positions.
-     * The algorithm fills an array in which each node is placed at a suitable position for it.
+     *  The algorithm fills an array in which each node is placed at a suitable position for it.
      * @param destination The array in which each node is placed at a suitable position
      * @param source The source list of nodes
      * @return Mapping result, {@code true} if such a mapping is possible (array was filled)

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/NodeReplacer.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/NodeReplacer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/NodeReplacer.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/NodeReplacer.java
@@ -32,7 +32,6 @@ import org.cqfn.astranaut.core.utils.Pair;
 
 /**
  * Creator of a new tree with a modified subtree.
- *
  * @since 1.0
  */
 public class NodeReplacer {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/NodeSelector.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/NodeSelector.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/NodeSelector.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/NodeSelector.java
@@ -31,7 +31,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * An algorithm that selects nodes from a tree based on some criteria.
- *
  * @since 1.1.4
  */
 public final class NodeSelector {
@@ -77,7 +76,6 @@ public final class NodeSelector {
 
     /**
      * Walker that traverses the syntax tree and selects nodes.
-     *
      * @since 1.1.4
      */
     private static final class Walker {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/PatternBuilder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/PatternBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/PatternBuilder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/PatternBuilder.java
@@ -127,8 +127,7 @@ public final class PatternBuilder {
 
     /**
      * Some additional information about each node needed to make holes.
-     * So far there's only a parent node here, but we may need something else.
-     *
+     *  So far there's only a parent node here, but we may need something else.
      * @since 1.1.5
      */
     private static final class NodeInfo {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/SubtreeBuilder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/SubtreeBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Adapter.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Adapter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Adapter.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Adapter.java
@@ -84,7 +84,7 @@ public class Adapter {
 
     /**
      * Converts the [sub]tree to another applying the specified variant
-     * of conversion.
+     *  of conversion.
      * @param variant The variant index
      * @param root The root node of the subtree
      * @return A converted tree or empty tree if the conversion is impossible
@@ -111,7 +111,7 @@ public class Adapter {
 
     /**
      * Calculate an amount of possible conversions that one rule may conduct
-     * within the tree.
+     *  within the tree.
      * @param root The root node of the subtree
      * @return Amount of conversions
      */
@@ -151,8 +151,8 @@ public class Adapter {
 
     /**
      * Creates a list from nodes.
-     * The list is sorted in descending order of nodes depth in the tree.
-     * Leaf nodes are at the beginning of the list, and the last element is the root.
+     *  The list is sorted in descending order of nodes depth in the tree.
+     *  Leaf nodes are at the beginning of the list, and the last element is the root.
      * @since 0.2.2
      */
     private static class NodeListBuilder {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Converter.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Converter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Converter.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Converter.java
@@ -28,14 +28,12 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Interface for converters that check one rule described in DSL
- * and convert the initial AST built to the specified target format.
- *
+ *  and convert the initial AST built to the specified target format.
  * @since 1.0
  */
 public interface Converter {
     /**
      * Converts an initial AST to the target format.
-     *
      * @param node The root of the AST to be converted
      * @param factory The node factory
      * @return A new node

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Matcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Matcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Matcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/Matcher.java
@@ -29,8 +29,7 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Checks if the node matches some structure and extracts the data or (and) children
- * if the latter are used in the target [sub]tree.
- *
+ *  if the latter are used in the target [sub]tree.
  * @since 1.0
  */
 public interface Matcher {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/conversion/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/hash/AbsoluteHash.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/hash/AbsoluteHash.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/hash/Hash.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/hash/Hash.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/hash/Hash.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/hash/Hash.java
@@ -28,8 +28,7 @@ import org.cqfn.astranaut.core.base.Tree;
 
 /**
  * An interface that calculates the hash of a node.
- * Hash is a number that uniquely identifies a node by some criteria.
- *
+ *  Hash is a number that uniquely identifies a node by some criteria.
  * @since 1.1.0
  */
 public interface Hash {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/hash/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/hash/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/hash/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/hash/package-info.java
@@ -24,8 +24,7 @@
 
 /**
  * This package contains algorithms that calculate the hash of a node.
- * Hash is a number that uniquely identifies a node by some criteria.
- *
+ *  Hash is a number that uniquely identifies a node by some criteria.
  * @since 1.1.0
  */
 package org.cqfn.astranaut.core.algorithms.hash;

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/ExtInsertion.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/ExtInsertion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Mapper.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Mapper.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Mapper.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Mapper.java
@@ -27,7 +27,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * A mapper that builds correspondences between two trees.
- *
  * @since 1.1.0
  */
 public interface Mapper {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Mapping.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Mapping.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Mapping.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Mapping.java
@@ -68,7 +68,7 @@ public interface Mapping {
 
     /**
      * Returns the set of nodes of the 'left' tree that need to be removed
-     * to get the 'right' tree.
+     *  to get the 'right' tree.
      * @return The set of deleted nodes
      */
     Set<Node> getDeleted();

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/NodePairFinder.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/NodePairFinder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Section.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Section.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Section.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Section.java
@@ -124,8 +124,8 @@ final class Section {
 
     /**
      * Creates a new section with the specified node removed from both left and right subsets.
-     * If the node is not present in either subset, the original section is returned.
-     * If this removal results in both subsets becoming empty, returns null.
+     *  If the node is not present in either subset, the original section is returned.
+     *  If this removal results in both subsets becoming empty, returns null.
      * @param node Node to be removed
      * @return A new section instance without the specified node, or {@code null} if the result
      *  is empty
@@ -287,7 +287,7 @@ final class Section {
 
     /**
      * Splits a list of nodes into two using the specified node as a delimiter.
-     * The delimiter is not included in either set.
+     *  The delimiter is not included in either set.
      * @param list List of nodes
      * @param node Delimiter node
      * @return Pair of resulting lists

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownAlgorithm.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownAlgorithm.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownMapper.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownMapper.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownMapping.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownMapping.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Unprocessed.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/Unprocessed.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/mapping/package-info.java
@@ -24,8 +24,7 @@
 
 /**
  * This package contains algorithms and data structures related to mapping
- * one syntax tree to another.
- *
+ *  one syntax tree to another.
  * @since 1.1.0
  */
 package org.cqfn.astranaut.core.algorithms.mapping;

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/NormalizedNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/NormalizedNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/NormalizedNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/NormalizedNode.java
@@ -255,4 +255,3 @@ public final class NormalizedNode extends NodeAndType implements PrototypeBasedN
         }
     }
 }
-

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/Properties.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/Properties.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/Property.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/Property.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/normalization/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * The package contains algorithms for processing trees described by astranaut structures.
- *
  * @since 1.1.0
  */
 package org.cqfn.astranaut.core.algorithms;

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/DefaultPatcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/DefaultPatcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/DefaultPatcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/DefaultPatcher.java
@@ -32,8 +32,7 @@ import org.cqfn.astranaut.core.base.Tree;
 
 /**
  * Default algorithm that applies patches, i.e. makes some changes in the syntax tree
- * based on patterns describing such changes. Patterns are differential trees.
- *
+ *  based on patterns describing such changes. Patterns are differential trees.
  * @since 1.1.5
  */
 public final class DefaultPatcher implements Patcher {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
@@ -41,7 +41,6 @@ import org.cqfn.astranaut.core.base.Tree;
 
 /**
  * The matcher matches syntax tree and patterns.
- *
  * @since 1.1.5
  */
 class Matcher {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
@@ -144,21 +144,24 @@ class Matcher {
             result = true;
             final Iterator<Node> iterator = sample.getIteratorOverChildren();
             int offset = 0;
-            Node current = null;
+            Node previous = null;
             while (result && offset < right && iterator.hasNext()) {
                 final Node child = iterator.next();
                 final Action action = Action.toAction(child);
                 if (action instanceof Insert) {
-                    applicants.insertNodeAfter(action.getAfter(), node, current);
+                    final Node insertion = action.getAfter();
+                    applicants.insertNodeAfter(insertion, node, previous);
+                    previous = insertion;
                 } else if (index + offset >= left) {
                     result = false;
                 } else {
-                    current = node.getChild(index + offset);
+                    final Node current = node.getChild(index + offset);
                     result = Matcher.checkNode(
                         current,
                         child,
                         applicants
                     );
+                    previous = current;
                     offset = offset + 1;
                 }
             }

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Patcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Patcher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Patcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Patcher.java
@@ -28,8 +28,7 @@ import org.cqfn.astranaut.core.base.Tree;
 
 /**
  * Interface to an algorithm that applies patches, i.e. makes some changes in the syntax tree
- * based on patterns describing such changes. Patterns are differential trees.
- *
+ *  based on patterns describing such changes. Patterns are differential trees.
  * @since 1.1.5
  */
 public interface Patcher {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/package-info.java
@@ -24,8 +24,7 @@
 
 /**
  * This package contains algorithms and data structures related to patching, i.e., changing
- * syntax trees using patterns (difference trees).
- *
+ *  syntax trees using patterns (difference trees).
  * @since 1.1.5
  */
 package org.cqfn.astranaut.core.algorithms.patching;

--- a/src/main/java/org/cqfn/astranaut/core/base/Action.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Action.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/ActionList.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/ActionList.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Builder.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Builder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Builder.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Builder.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 /**
  * Object that creates nodes.
- *
  * @since 1.0
  */
 public interface Builder {

--- a/src/main/java/org/cqfn/astranaut/core/base/ChildDescriptor.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/ChildDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/CoreException.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/CoreException.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/CoreException.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/CoreException.java
@@ -25,7 +25,6 @@ package org.cqfn.astranaut.core.base;
 
 /**
  * Helper class for custom exceptions in projects that use the core as a dependency.
- *
  * @since 1.0.2
  */
 public abstract class CoreException extends Exception {

--- a/src/main/java/org/cqfn/astranaut/core/base/DefaultFactory.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DefaultFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/DefaultFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DefaultFragment.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/DefaultPosition.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DefaultPosition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Delete.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Delete.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Delete.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Delete.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 
 /**
  * Action that deletes a child element.
- *
  * @since 1.1.0
  */
 public final class Delete implements Action {
@@ -102,7 +101,6 @@ public final class Delete implements Action {
 
     /**
      * Type of 'Delete' action.
-     *
      * @since 1.1.0
      */
     private static final class DeleteType implements Type {
@@ -179,7 +177,6 @@ public final class Delete implements Action {
 
     /**
      * Class for 'Delete' action construction.
-     *
      * @since 1.1.0
      */
     public static final class Constructor implements Builder {

--- a/src/main/java/org/cqfn/astranaut/core/base/DiffNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DiffNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/DiffNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DiffNode.java
@@ -31,7 +31,6 @@ import java.util.Map;
 
 /**
  * Node containing child nodes, as well as actions on these nodes.
- *
  * @since 1.1.0
  */
 public final class DiffNode extends NodeAndType implements DiffTreeItem, PrototypeBasedNode {
@@ -134,7 +133,7 @@ public final class DiffNode extends NodeAndType implements DiffTreeItem, Prototy
 
     /**
      * Adds an action that inserts the node after another node.
-     * If no other node is specified, inserts at the beginning of the children's list.
+     *  If no other node is specified, inserts at the beginning of the children's list.
      * @param node Node to be inserted
      * @param after Node after which to insert
      * @return Result of operation, @return {@code true} if action was added
@@ -161,7 +160,7 @@ public final class DiffNode extends NodeAndType implements DiffTreeItem, Prototy
 
     /**
      * Adds an action that replaces a node.
-     * The position of the node is specified by the index.
+     *  The position of the node is specified by the index.
      * @param index Node index
      * @param replacement Child node to be replaced by
      * @return Result of operation, @return {@code true} if action was added
@@ -308,7 +307,6 @@ public final class DiffNode extends NodeAndType implements DiffTreeItem, Prototy
 
     /**
      * Selector that selects some branch from a difference tree item: before or after the changes.
-     *
      * @since 1.1.0
      */
     private interface BranchSelector {

--- a/src/main/java/org/cqfn/astranaut/core/base/DiffTree.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DiffTree.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/DiffTree.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DiffTree.java
@@ -31,7 +31,6 @@ package org.cqfn.astranaut.core.base;
  * Thus, a DifferentialTree encapsulates both the original tree and the modified
  *  tree, detailing the differences and the changes needed to transition from one
  *  to the other.
- *
  * @since 2.0.0
  */
 public final class DiffTree extends Tree {

--- a/src/main/java/org/cqfn/astranaut/core/base/DiffTreeItem.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DiffTreeItem.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/DiffTreeItem.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DiffTreeItem.java
@@ -25,7 +25,6 @@ package org.cqfn.astranaut.core.base;
 
 /**
  * An element of the difference tree.
- *
  * @since 1.1.0
  */
 public interface DiffTreeItem extends Node {

--- a/src/main/java/org/cqfn/astranaut/core/base/DraftNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DraftNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/DraftNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DraftNode.java
@@ -40,7 +40,7 @@ import java.util.Set;
  *  the creation of any tree structure without validation, making it suitable for testing
  *  purposes and for displaying trees obtained from third-party parsers in the ASTranaut
  *  format.<br/>
- * DraftNode is designed to be immutable.
+ *  DraftNode is designed to be immutable.
  * @since 1.0
  */
 public final class DraftNode extends NodeAndType {

--- a/src/main/java/org/cqfn/astranaut/core/base/DummyNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DummyNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/EmptyFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/EmptyFragment.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/EmptyFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/EmptyFragment.java
@@ -27,7 +27,6 @@ package org.cqfn.astranaut.core.base;
  * {@code EmptyFragment} is an implementation of {@link Fragment} representing an empty fragment.
  *  It serves as a placeholder when a node does not have an associated fragment
  *  preventing the need to return a null pointer.
- *
  * @since 1.0
  */
 public final class EmptyFragment implements Fragment {

--- a/src/main/java/org/cqfn/astranaut/core/base/EmptyTree.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/EmptyTree.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/ExtNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/ExtNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Factory.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Factory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/FactoryProvider.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/FactoryProvider.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Fragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Fragment.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Fragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Fragment.java
@@ -25,7 +25,6 @@ package org.cqfn.astranaut.core.base;
 
 /**
  * Describes a fragment of source code.
- *
  * @since 1.0
  */
 public interface Fragment {

--- a/src/main/java/org/cqfn/astranaut/core/base/Hole.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Hole.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Hole.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Hole.java
@@ -28,7 +28,6 @@ import org.cqfn.astranaut.core.utils.MapUtils;
 
 /**
  * A special pattern node that can substitute for any node of a suitable type.
- *
  * @since 1.1.5
  */
 public final class Hole extends NodeAndType implements PatternItem, PrototypeBasedNode {

--- a/src/main/java/org/cqfn/astranaut/core/base/Insert.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Insert.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Insert.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Insert.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 
 /**
  * An action that inserts a child element.
- *
  * @since 1.1.0
  */
 public final class Insert implements Action {
@@ -102,7 +101,6 @@ public final class Insert implements Action {
 
     /**
      * Type of 'Insert' action.
-     *
      * @since 1.1.0
      */
     private static final class InsertType implements Type {
@@ -179,7 +177,6 @@ public final class Insert implements Action {
 
     /**
      * Class for 'Delete' action construction.
-     *
      * @since 1.1.0
      */
     public static final class Constructor implements Builder {

--- a/src/main/java/org/cqfn/astranaut/core/base/Insertion.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Insertion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Insertion.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Insertion.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 
 /**
  * This class contains information about the node being inserted as a child of another node.
- *
  * @since 1.1.0
  */
 public final class Insertion {

--- a/src/main/java/org/cqfn/astranaut/core/base/MutableNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/MutableNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/MutableNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/MutableNode.java
@@ -29,7 +29,6 @@ import java.util.List;
 
 /**
  * Mutable node whose children can be replaced during syntactic tree customization.
- *
  * @since 1.0
  */
 public final class MutableNode implements PrototypeBasedNode {

--- a/src/main/java/org/cqfn/astranaut/core/base/Node.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Node.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Node.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Node.java
@@ -35,14 +35,13 @@ import java.util.function.Consumer;
 
 /**
  * The {@code Node} interface represents a node in an abstract syntax tree (AST).
- * This is our foundational interface on which the entire platform is built.
- * The interface contains a minimal number of non-default methods, making it
- * easy to create custom nodes by requiring the implementation of only a few methods.
- * Additionally, the interface is designed to allow for automatic generation
- * of classes based on it.
- * The interface is designed to be immutable, which ensures thread safety and
- * consistency, as well as simplifying the debugging process.
- *
+ *  This is our foundational interface on which the entire platform is built.
+ *  The interface contains a minimal number of non-default methods, making it
+ *  easy to create custom nodes by requiring the implementation of only a few methods.
+ *  Additionally, the interface is designed to allow for automatic generation
+ *  of classes based on it.
+ *  The interface is designed to be immutable, which ensures thread safety and
+ *  consistency, as well as simplifying the debugging process.
  * @since 1.0
  */
 @SuppressWarnings("PMD.ExcessivePublicCount")
@@ -217,7 +216,6 @@ public interface Node {
 
     /**
      * Iterator that enumerates the children of a node.
-     *
      * @since 1.1.5
      */
     class ChildrenIterator implements ListIterator<Node> {
@@ -303,7 +301,6 @@ public interface Node {
      *  minimal overhead and optimal performance for operations involving child
      *  nodes. Using the List interface for child nodes is frequent in our codebase
      *  due to its convenience and flexibility in handling node collections.
-     *
      * @since 2.0.0
      */
     @SuppressWarnings("PMD.TooManyMethods")

--- a/src/main/java/org/cqfn/astranaut/core/base/NodeAndType.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/NodeAndType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Pattern.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Pattern.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Pattern.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Pattern.java
@@ -34,7 +34,6 @@ package org.cqfn.astranaut.core.base;
  *  (i.e., the source code from which this syntax tree was derived) to another, unrelated
  *  syntax tree. One possible application of such a mechanism is the detection and automatic
  *  correction of errors in source code.
- *
  * @since 2.0.0
  */
 public final class Pattern extends Tree {

--- a/src/main/java/org/cqfn/astranaut/core/base/PatternItem.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/PatternItem.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/PatternItem.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/PatternItem.java
@@ -25,7 +25,6 @@ package org.cqfn.astranaut.core.base;
 
 /**
  * An element of a pattern.
- *
  * @since 1.1.5
  */
 public interface PatternItem extends Node {

--- a/src/main/java/org/cqfn/astranaut/core/base/PatternNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/PatternNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/PatternNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/PatternNode.java
@@ -30,7 +30,6 @@ import java.util.Map;
 /**
  * A node that contains child nodes as well as actions on those nodes.
  * Child nodes can be replaced by holes.
- *
  * @since 1.1.5
  */
 public final class PatternNode extends NodeAndType implements PatternItem, PrototypeBasedNode {

--- a/src/main/java/org/cqfn/astranaut/core/base/Position.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Position.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Position.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Position.java
@@ -28,7 +28,6 @@ package org.cqfn.astranaut.core.base;
  *  It provides methods to retrieve the source, row, and column of the position.
  *  Positions are comparable based on their source, row, and column. If positions
  *  have different sources, they are considered incomparable.
- *
  * @since 1.0
  */
 public interface Position extends Comparable<Position> {

--- a/src/main/java/org/cqfn/astranaut/core/base/PrototypeBasedNode.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/PrototypeBasedNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Replace.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Replace.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Replace.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Replace.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 
 /**
  * Action that replaces a child element.
- *
  * @since 1.1.0
  */
 public final class Replace implements Action {
@@ -116,7 +115,6 @@ public final class Replace implements Action {
 
     /**
      * Type of 'Replace' action.
-     *
      * @since 1.1.0
      */
     private static final class ReplaceType implements Type {
@@ -197,7 +195,6 @@ public final class Replace implements Action {
 
     /**
      * Class for 'Delete' action construction.
-     *
      * @since 1.1.0
      */
     public static final class Constructor implements Builder {

--- a/src/main/java/org/cqfn/astranaut/core/base/Source.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Source.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Source.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Source.java
@@ -25,13 +25,11 @@ package org.cqfn.astranaut.core.base;
 
 /**
  * Represents a source code file.
- *
  * @since 1.0
  */
 public interface Source {
     /**
      * Return a string for a source code fragment within the specified range.
-     *
      * @param start Start position
      * @param end End position
      * @return Text of the fragment

--- a/src/main/java/org/cqfn/astranaut/core/base/Tree.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Tree.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Tree.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Tree.java
@@ -29,7 +29,6 @@ import java.util.Set;
 /**
  * A syntax tree, which represents the hierarchical structure of source code,
  *  depicting the syntactic structure and relationships between code elements.
- *
  * @since 2.0.0
  */
 public class Tree {

--- a/src/main/java/org/cqfn/astranaut/core/base/Type.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Type.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/Type.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Type.java
@@ -29,7 +29,6 @@ import java.util.Map;
 
 /**
  * A type of abstract syntax tree node.
- *
  * @since 1.0
  */
 public interface Type {

--- a/src/main/java/org/cqfn/astranaut/core/base/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/base/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/package-info.java
@@ -24,8 +24,7 @@
 
 /**
  * This package tests the basic structures describing syntax trees and their subtypes,
- * as well as some auxiliary classes that facilitate the construction of these basic structures.
- *
+ *  as well as some auxiliary classes that facilitate the construction of these basic structures.
  * @since 2.0.0
  */
 package org.cqfn.astranaut.core.base;

--- a/src/main/java/org/cqfn/astranaut/core/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains base classes that define the syntax tree structure.
- *
  * @since 1.0
  */
 package org.cqfn.astranaut.core;

--- a/src/main/java/org/cqfn/astranaut/core/utils/FilesReader.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/FilesReader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/FilesReader.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/FilesReader.java
@@ -31,7 +31,6 @@ import java.nio.file.Paths;
 
 /**
  * Class for reading files.
- *
  * @since 1.0.2
  */
 public final class FilesReader {

--- a/src/main/java/org/cqfn/astranaut/core/utils/FilesWriter.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/FilesWriter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/FilesWriter.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/FilesWriter.java
@@ -32,7 +32,6 @@ import java.nio.file.Paths;
 
 /**
  * Class for writing files.
- *
  * @since 1.0.2
  */
 public final class FilesWriter {

--- a/src/main/java/org/cqfn/astranaut/core/utils/JsonDeserializer.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/JsonDeserializer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/JsonDeserializer.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/JsonDeserializer.java
@@ -32,7 +32,6 @@ import org.cqfn.astranaut.core.utils.deserializer.TreeDescriptor;
 
 /**
  * Converts a string that contains a JSON object to a tree.
- *
  * @since 1.0.2
  */
 public final class JsonDeserializer {

--- a/src/main/java/org/cqfn/astranaut/core/utils/JsonSerializer.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/JsonSerializer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/JsonSerializer.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/JsonSerializer.java
@@ -34,7 +34,6 @@ import org.cqfn.astranaut.core.base.Type;
 
 /**
  * Converts a tree to a string that contains JSON object.
- *
  * @since 1.0.2
  */
 public final class JsonSerializer {
@@ -119,7 +118,7 @@ public final class JsonSerializer {
 
     /**
      * Converts the tree to a string that contains a JSON object and
-     * writes the result to a file.
+     *  writes the result to a file.
      * @param filename The file name
      * @return The result, {@code true} if the file was successful written
      */

--- a/src/main/java/org/cqfn/astranaut/core/utils/ListUtils.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/ListUtils.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/ListUtils.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/ListUtils.java
@@ -29,7 +29,6 @@ import java.util.List;
 
 /**
  * Helper class for building lists.
- *
  * @param <T> Item type
  * @since 1.0
  */

--- a/src/main/java/org/cqfn/astranaut/core/utils/MapUtils.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/MapUtils.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/MapUtils.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/MapUtils.java
@@ -29,7 +29,6 @@ import java.util.Map;
 
 /**
  * Helper class for building maps.
- *
  * @param <K> Key type
  * @param <V> Value type
  * @since 2.0.0

--- a/src/main/java/org/cqfn/astranaut/core/utils/Pair.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/Pair.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/Pair.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/Pair.java
@@ -25,10 +25,8 @@ package org.cqfn.astranaut.core.utils;
 
 /**
  * Simple pair in case someone needs to use (key, val) objects without creating a map.
- *
  * @param <K> The key type
  * @param <V> The value type
- *
  * @since 1.0
  */
 public final class Pair<K, V> {

--- a/src/main/java/org/cqfn/astranaut/core/utils/Promise.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/Promise.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/TreeVisualizer.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/TreeVisualizer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/TreeVisualizer.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/TreeVisualizer.java
@@ -50,7 +50,7 @@ public final class TreeVisualizer {
 
     /**
      * Renders a DOT text of the tree, renders an image from it and
-     * saves it to the specified file.
+     *  saves it to the specified file.
      * @param file A file of the AST visualization
      * @throws IOException If an error during input or output actions occurs
      * @throws WrongFileExtension If an error during visualization occurs

--- a/src/main/java/org/cqfn/astranaut/core/utils/deserializer/NodeDescriptor.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/deserializer/NodeDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/deserializer/NodeDescriptor.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/deserializer/NodeDescriptor.java
@@ -38,7 +38,6 @@ import org.cqfn.astranaut.core.utils.Promise;
 
 /**
  * Node descriptor represented as it is stored in the JSON file.
- *
  * @since 1.1.0
  */
 public class NodeDescriptor {

--- a/src/main/java/org/cqfn/astranaut/core/utils/deserializer/TreeDescriptor.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/deserializer/TreeDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/deserializer/TreeDescriptor.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/deserializer/TreeDescriptor.java
@@ -36,7 +36,6 @@ import org.cqfn.astranaut.core.base.Tree;
 
 /**
  * Tree descriptor represented as it is stored in the JSON file.
- *
  * @since 1.1.0
  */
 public class TreeDescriptor {

--- a/src/main/java/org/cqfn/astranaut/core/utils/deserializer/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/deserializer/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/deserializer/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/deserializer/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains helper classes for the JSON deserializer.
- *
  * @since 1.1.0
  */
 package org.cqfn.astranaut.core.utils.deserializer;

--- a/src/main/java/org/cqfn/astranaut/core/utils/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains helper classes.
- *
  * @since 1.0.2
  */
 package org.cqfn.astranaut.core.utils;

--- a/src/main/java/org/cqfn/astranaut/core/utils/visualizer/DotGenerator.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/visualizer/DotGenerator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/visualizer/DotGenerator.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/visualizer/DotGenerator.java
@@ -76,7 +76,6 @@ public class DotGenerator {
 
     /**
      * Renders data to a DOT format.
-     *
      * @return A rendered DOT text as string
      */
     public String generate() {
@@ -88,7 +87,6 @@ public class DotGenerator {
 
     /**
      * Processes a node with all its children.
-     *
      * @param node A node.
      */
     private void processNode(final Node node) {
@@ -165,7 +163,6 @@ public class DotGenerator {
 
     /**
      * Appends tree edge text.
-     *
      * @param parent A parent node index
      * @param child A child node index
      * @param label An edge label
@@ -185,8 +182,7 @@ public class DotGenerator {
 
     /**
      * Encodes text into an HTML-compatible format replacing characters,
-     * which are not accepted in HTML, with corresponding HTML escape symbols.
-     *
+     *  which are not accepted in HTML, with corresponding HTML escape symbols.
      * @param str Text to be encoded in HTML
      * @return An encoded text
      */

--- a/src/main/java/org/cqfn/astranaut/core/utils/visualizer/ImageRender.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/visualizer/ImageRender.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/visualizer/ImageRender.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/visualizer/ImageRender.java
@@ -34,7 +34,6 @@ import java.util.Optional;
 
 /**
  * Renders an image from a tree using the external Graphviz tool.
- *
  * @since 1.0.2
  */
 public class ImageRender {

--- a/src/main/java/org/cqfn/astranaut/core/utils/visualizer/WrongFileExtension.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/visualizer/WrongFileExtension.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/visualizer/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/visualizer/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/cqfn/astranaut/core/utils/visualizer/package-info.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/visualizer/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains helper classes for the tree visualizer.
- *
  * @since 1.1.0
  */
 package org.cqfn.astranaut.core.utils.visualizer;

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/DepthCalculatorTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/DepthCalculatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/DepthCalculatorTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/DepthCalculatorTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Testing {@link DepthCalculator} class.
- *
  * @since 1.1.0
  */
 class DepthCalculatorTest {

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/DepthFirstWalkerTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/DepthFirstWalkerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/DepthFirstWalkerTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/DepthFirstWalkerTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Testing {@link DepthFirstWalker} class.
- *
  * @since 1.1.5
  */
 class DepthFirstWalkerTest {

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/DiffTreeBuilderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/DiffTreeBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/DiffTreeBuilderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/DiffTreeBuilderTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Testing {@link DiffTreeBuilder} class.
- *
  * @since 1.1.0
  */
 class DiffTreeBuilderTest {
@@ -105,11 +104,6 @@ class DiffTreeBuilderTest {
         Assertions.assertTrue(after.deepCompare(diff.getAfter().getRoot()));
     }
 
-    /**
-     * Testing the construction of a difference tree with a deleted node.
-     * This node is just below the root, so that the number and type of children of the root
-     * do not change.
-     */
     @Test
     void testTreeWithDeletedNodeInDepth() {
         final Node before = LittleTrees.createStatementBlock(

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/IdenticalNodeFinderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/IdenticalNodeFinderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/IdenticalNodeFinderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/IdenticalNodeFinderTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link IdenticalNodeFinder} class.
- *
  * @since 1.1.5
  */
 class IdenticalNodeFinderTest {

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/LabeledTreeBuilderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/LabeledTreeBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/NodeAllocatorTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/NodeAllocatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/NodeAllocatorTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/NodeAllocatorTest.java
@@ -454,7 +454,6 @@ class NodeAllocatorTest {
 
     /**
      * Node descriptor for testing.
-     *
      * @since 1.0
      */
     private static final class NodeDescriptor {

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/NodeReplacerTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/NodeReplacerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/NodeReplacerTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/NodeReplacerTest.java
@@ -33,13 +33,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link NodeReplacer} class.
- *
  * @since 1.0
  */
 class NodeReplacerTest {
-    /**
-     * Testing tree recreation when a root is the node to be replaced.
-     */
     @Test
     void testReplacementOfRoot() {
         final Node root =
@@ -78,9 +74,6 @@ class NodeReplacerTest {
         Assertions.assertEquals(-1, result.getValue());
     }
 
-    /**
-     * Testing tree recreation when a root child is the node to be replaced.
-     */
     @Test
     void testReplacementOfRootChild() {
         final Node source =
@@ -121,9 +114,6 @@ class NodeReplacerTest {
         Assertions.assertEquals(2, result.getValue());
     }
 
-    /**
-     * Testing tree recreation when a child of a root child is the node to be replaced.
-     */
     @Test
     void testReplacementOfRootGrandChild() {
         final Node source = this.createNode("2300", "");
@@ -164,9 +154,6 @@ class NodeReplacerTest {
         Assertions.assertEquals(2, result.getValue());
     }
 
-    /**
-     * Testing tree recreation when a source subtree to be replaced is not found.
-     */
     @Test
     void testReplacementWithoutMatch() {
         final Node root =
@@ -183,10 +170,6 @@ class NodeReplacerTest {
         Assertions.assertEquals(-1, result.getValue());
     }
 
-    /**
-     * Creates a target tree for replacement.
-     * @return A new tree
-     */
     private Node createTargetTree() {
         return this.createNode(
             "2",

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/NodeSelectorTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/NodeSelectorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/NodeSelectorTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/NodeSelectorTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link NodeSelector}.
- *
  * @since 1.1.4
  */
 class NodeSelectorTest {

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/PatternBuilderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/PatternBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/PatternBuilderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/PatternBuilderTest.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Testing {@link PatternBuilder} class.
- *
  * @since 1.1.0
  */
 class PatternBuilderTest {

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/SubtreeBuilderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/SubtreeBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/SubtreeBuilderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/SubtreeBuilderTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link SubtreeBuilder}.
- *
  * @since 1.1.4
  */
 class SubtreeBuilderTest {

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/conversion/AdapterTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/conversion/AdapterTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/conversion/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/conversion/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/hash/AbsoluteHashTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/hash/AbsoluteHashTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/hash/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/hash/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/hash/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/hash/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains tests covering hash algorithms.
- *
  * @since 1.1.0
  */
 package org.cqfn.astranaut.core.algorithms.hash;

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/NodePairFinderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/NodePairFinderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/SectionTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/SectionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownMapperTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownMapperTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownMapperTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/TopDownMapperTest.java
@@ -453,6 +453,42 @@ class TopDownMapperTest {
         Assertions.assertTrue(after.deepCompare(second));
     }
 
+    @Test
+    void testOrderOfInsertions() {
+        final Node first = DraftNode.create("A(B,F)");
+        final Node second = DraftNode.create("A(B,C,D,E,F)");
+        final Mapper mapper = TopDownMapper.INSTANCE;
+        final Mapping mapping = mapper.map(first, second);
+        final List<Insertion> inserted = mapping.getInserted();
+        Assertions.assertEquals(3, inserted.size());
+        Assertions.assertEquals("C", inserted.get(0).getNode().getTypeName());
+        Assertions.assertEquals("D", inserted.get(1).getNode().getTypeName());
+        Assertions.assertEquals("E", inserted.get(2).getNode().getTypeName());
+        final DiffTreeBuilder builder = new DiffTreeBuilder(first);
+        builder.build(second, mapper);
+        final DiffTree diff = builder.getDiffTree();
+        final Node third = diff.getAfter().getRoot();
+        Assertions.assertTrue(third.deepCompare(second));
+    }
+
+    @Test
+    void testOrderOfInsertionsAtBeginning() {
+        final Node first = DraftNode.create("A(F)");
+        final Node second = DraftNode.create("A(C,D,E,F)");
+        final Mapper mapper = TopDownMapper.INSTANCE;
+        final Mapping mapping = mapper.map(first, second);
+        final List<Insertion> inserted = mapping.getInserted();
+        Assertions.assertEquals(3, inserted.size());
+        Assertions.assertEquals("C", inserted.get(0).getNode().getTypeName());
+        Assertions.assertEquals("D", inserted.get(1).getNode().getTypeName());
+        Assertions.assertEquals("E", inserted.get(2).getNode().getTypeName());
+        final DiffTreeBuilder builder = new DiffTreeBuilder(first);
+        builder.build(second, mapper);
+        final DiffTree diff = builder.getDiffTree();
+        final Node third = diff.getAfter().getRoot();
+        Assertions.assertTrue(third.deepCompare(second));
+    }
+
     /**
      * Returns content of the specified file.
      * @param name The name of the file

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/UnprocessedTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/UnprocessedTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/mapping/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains tests covering mapping algorithms.
- *
  * @since 1.1.0
  */
 package org.cqfn.astranaut.core.algorithms.mapping;

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/NormalizedNodeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/NormalizedNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/PropertiesTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/PropertiesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/PropertyTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/PropertyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/normalization/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains tests covering normalization algorithms.
- *
  * @since 2.0.0
  */
 package org.cqfn.astranaut.core.algorithms.normalization;

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains tests covering various algorithms.
- *
  * @since 1.1.0
  */
 package org.cqfn.astranaut.core.algorithms;

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/MatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/MatcherTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/MatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/MatcherTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Testing {@link Matcher} class.
- *
  * @since 1.1.5
  */
 class MatcherTest {

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Testing {@link Patcher} class.
- *
  * @since 1.1.5
  */
 class PatcherTest {
@@ -228,6 +227,22 @@ class PatcherTest {
         final Patcher patcher = DefaultPatcher.INSTANCE;
         final Tree patched = patcher.patch(original, pattern);
         final Tree expected = Tree.createDraft("Y(X(A,B,C,D),E,F)");
+        Assertions.assertEquals(expected.toString(), patched.toString());
+    }
+
+    @Test
+    void mineAndPatchOneInsertionAndOneDeletion() {
+        final Node before = DraftNode.create("X(Y,Z,D)");
+        final Node after = DraftNode.create("X(Z,A,B,C,D)");
+        final Mapper mapper = TopDownMapper.INSTANCE;
+        final DiffTreeBuilder diffbuilder = new DiffTreeBuilder(before);
+        diffbuilder.build(after, mapper);
+        final DiffTree diff = diffbuilder.getDiffTree();
+        final Pattern pattern = new PatternBuilder(diff).getPattern();
+        final Tree original = Tree.createDraft("Y(X(Y,Z,D),E,F)");
+        final Patcher patcher = DefaultPatcher.INSTANCE;
+        final Tree patched = patcher.patch(original, pattern);
+        final Tree expected = Tree.createDraft("Y(X(Z,A,B,C,D),E,F)");
         Assertions.assertEquals(expected.toString(), patched.toString());
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
@@ -192,7 +192,7 @@ class PatcherTest {
     }
 
     @Test
-    void mineAndPatch() {
+    void mineAndPatchComplexCase() {
         final Node before = DraftNode.create("X(A,C(D(F(G(H)))))");
         final Node after = DraftNode.create("X(A,B,C(D(F(G(I)))))");
         final Mapper mapper = TopDownMapper.INSTANCE;
@@ -210,6 +210,24 @@ class PatcherTest {
         final Tree expected = Tree.createDraft(
             "Y(X(A,C(D(F(G(J,K))))),X(A,C(D(F(G(L))))),X(A,B,C(D(F(G(I))))))"
         );
+        Assertions.assertEquals(expected.toString(), patched.toString());
+    }
+
+    @Test
+    void mineAndPatchThreeInsertions() {
+        final Node before = DraftNode.create("X(D)");
+        final Node after = DraftNode.create("X(A,B,C,D)");
+        final Mapper mapper = TopDownMapper.INSTANCE;
+        final DiffTreeBuilder diffbuilder = new DiffTreeBuilder(before);
+        diffbuilder.build(after, mapper);
+        final DiffTree diff = diffbuilder.getDiffTree();
+        Assertions.assertTrue(before.deepCompare(diff.getBefore().getRoot()));
+        Assertions.assertTrue(after.deepCompare(diff.getAfter().getRoot()));
+        final Pattern pattern = new PatternBuilder(diff).getPattern();
+        final Tree original = Tree.createDraft("Y(X(D),E,F)");
+        final Patcher patcher = DefaultPatcher.INSTANCE;
+        final Tree patched = patcher.patch(original, pattern);
+        final Tree expected = Tree.createDraft("Y(X(A,B,C,D),E,F)");
         Assertions.assertEquals(expected.toString(), patched.toString());
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains tests covering patching algorithms.
- *
  * @since 1.1.5
  */
 package org.cqfn.astranaut.core.algorithms.patching;

--- a/src/test/java/org/cqfn/astranaut/core/base/ActionTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/ActionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/ActionTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/ActionTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests covering actions, i.e. {@link Action} interface and inherited classes.
- *
  * @since 1.1.0
  */
 class ActionTest {
@@ -61,9 +60,6 @@ class ActionTest {
      */
     private static final String EXPECTED_COLOR = "blue";
 
-    /**
-     * Testing {@link Insert} action.
-     */
     @Test
     void testInsertAction() {
         final Node inserted = LittleTrees.createReturnStatement(null);
@@ -98,9 +94,6 @@ class ActionTest {
         Assertions.assertEquals(ActionTest.INSERT_TYPE, created.getTypeName());
     }
 
-    /**
-     * Testing {@link Replace} action.
-     */
     @Test
     void testReplaceAction() {
         final Node before = LittleTrees.createVariable("x");
@@ -138,9 +131,6 @@ class ActionTest {
         Assertions.assertEquals(ActionTest.REPLACE_TYPE, created.getTypeName());
     }
 
-    /**
-     * Testing {@link Delete} action.
-     */
     @Test
     void testDeleteAction() {
         final Node deleted = LittleTrees.createReturnStatement(null);

--- a/src/test/java/org/cqfn/astranaut/core/base/BaseInterfaceTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/BaseInterfaceTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/BaseInterfaceTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/BaseInterfaceTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests covering base interfaces, i.e. {@link Node}, {@link Type} and {@link Builder}.
- *
  * @since 1.1.0
  */
 @SuppressWarnings("PMD.TooManyMethods")

--- a/src/test/java/org/cqfn/astranaut/core/base/ChildDescriptorTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/ChildDescriptorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultPositionTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultPositionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/DiffNodeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DiffNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/DiffNodeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DiffNodeTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests covering difference node, i.e. {@link DiffNode} class.
- *
  * @since 1.1.0
  */
 @SuppressWarnings("PMD.TooManyMethods")

--- a/src/test/java/org/cqfn/astranaut/core/base/DraftNodeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DraftNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/DummyNodeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DummyNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/EmptyFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/EmptyFragmentTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/ExtNodeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/ExtNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/HoleTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/HoleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/HoleTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/HoleTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests covering {@link Hole} class.
- *
  * @since 1.1.5
  */
 class HoleTest {

--- a/src/test/java/org/cqfn/astranaut/core/base/MutableNodeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/MutableNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/PatternNodeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/PatternNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/PositionTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/PositionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/TreeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/TreeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/TreeTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/TreeTest.java
@@ -71,7 +71,6 @@ class TreeTest {
 
     /**
      * Node implementation for testing purposes.
-     *
      * @since 2.0.0
      */
     private static final class TestNode implements Node {
@@ -122,7 +121,6 @@ class TreeTest {
 
     /**
      * Type implementation for testing purposes.
-     *
      * @since 2.0.0
      */
     private static final class TestType implements Type {

--- a/src/test/java/org/cqfn/astranaut/core/base/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/base/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains tests covering various algorithms.
- *
  * @since 2.0.0
  */
 package org.cqfn.astranaut.core.base;

--- a/src/test/java/org/cqfn/astranaut/core/example/LittleTrees.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/LittleTrees.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/LittleTrees.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/LittleTrees.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Assertions;
 
 /**
  * Little trees for testing purposes.
- *
  * @since 1.1.0
  */
 @SuppressWarnings({"PMD.ProhibitPublicStaticMethods", "PMD.TooManyMethods"})

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Addition.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Addition.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Addition.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Addition.java
@@ -120,7 +120,6 @@ public final class Addition implements BinaryExpression {
 
     /**
      * Type descriptor of the 'Addition' node.
-     *
      * @since 1.0
      */
     private static class TypeImpl implements Type {
@@ -199,7 +198,6 @@ public final class Addition implements BinaryExpression {
 
     /**
      * Class for 'Addition' node construction.
-     *
      * @since 1.0
      */
     public static final class Constructor implements Builder {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/AssignableExpression.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/AssignableExpression.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/AssignableExpression.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/AssignableExpression.java
@@ -25,7 +25,6 @@ package org.cqfn.astranaut.core.example.green;
 
 /**
  * Node that describes the 'AssignableExpression' type.
- *
  * @since 1.0.5
  */
 public interface AssignableExpression extends Expression {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Assignment.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Assignment.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Assignment.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Assignment.java
@@ -26,7 +26,6 @@ package org.cqfn.astranaut.core.example.green;
 
 /**
  * Node that describes the 'Assignment' type.
- *
  * @since 1.1.0
  */
 public interface Assignment extends Expression {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/BinaryExpression.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/BinaryExpression.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/BinaryExpression.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/BinaryExpression.java
@@ -25,7 +25,6 @@ package org.cqfn.astranaut.core.example.green;
 
 /**
  * Node that describes the 'BinaryExpression' type.
- *
  * @since 1.0
  */
 public interface BinaryExpression extends Expression {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Expression.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Expression.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Expression.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Expression.java
@@ -27,7 +27,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Node that describes the 'Expression' type.
- *
  * @since 1.0
  */
 public interface Expression extends Node {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/ExpressionList.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/ExpressionList.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/ExpressionList.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/ExpressionList.java
@@ -39,7 +39,6 @@ import org.cqfn.astranaut.core.base.Type;
 
 /**
  * Node that describes the 'ExpressionList' type.
- *
  * @since 1.0
  */
 public final class ExpressionList implements Node {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/ExpressionStatement.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/ExpressionStatement.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/ExpressionStatement.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/ExpressionStatement.java
@@ -41,7 +41,6 @@ import org.cqfn.astranaut.core.utils.ListUtils;
 
 /**
  * Node that describes the 'ExpressionStatement' type.
- *
  * @since 1.1.0
  */
 public final class ExpressionStatement implements Statement {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/GreenFactory.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/GreenFactory.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/GreenFactory.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/GreenFactory.java
@@ -34,7 +34,6 @@ import org.cqfn.astranaut.core.base.Type;
 
 /**
  * Factory that creates 'green' nodes.
- *
  * @since 1.0
  */
 public final class GreenFactory extends DefaultFactory {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/IntegerLiteral.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/IntegerLiteral.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/IntegerLiteral.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/IntegerLiteral.java
@@ -38,7 +38,6 @@ import org.cqfn.astranaut.core.base.Type;
 
 /**
  * Node that describes the 'IntegerLiteral' type.
- *
  * @since 1.0
  */
 public final class IntegerLiteral implements Expression {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Return.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Return.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Return.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Return.java
@@ -41,7 +41,6 @@ import org.cqfn.astranaut.core.utils.ListUtils;
 
 /**
  * Node that describes the 'Return' type.
- *
  * @since 1.1.0
  */
 public final class Return implements Statement {
@@ -111,7 +110,6 @@ public final class Return implements Statement {
 
     /**
      * Type descriptor of the 'Return' node.
-     *
      * @since 1.1.0
      */
     private static class TypeImpl implements Type {
@@ -197,7 +195,6 @@ public final class Return implements Statement {
 
     /**
      * Class for 'Return' node construction.
-     *
      * @since 1.1.0
      */
     public static final class Constructor implements Builder {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/SimpleAssignment.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/SimpleAssignment.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/SimpleAssignment.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/SimpleAssignment.java
@@ -41,7 +41,6 @@ import org.cqfn.astranaut.core.utils.ListUtils;
 
 /**
  * Node that describes the 'SimpleAssignment' type.
- *
  * @since 1.1.0
  */
 public final class SimpleAssignment implements Assignment {
@@ -123,7 +122,6 @@ public final class SimpleAssignment implements Assignment {
 
     /**
      * Type descriptor of the 'SimpleAssignment' node.
-     *
      * @since 1.1.0
      */
     private static class TypeImpl implements Type {
@@ -213,7 +211,6 @@ public final class SimpleAssignment implements Assignment {
 
     /**
      * Class for 'SimpleAssignment' node construction.
-     *
      * @since 1.1.0
      */
     public static final class Constructor implements Builder {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Statement.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Statement.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Statement.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Statement.java
@@ -27,7 +27,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Node that describes the 'Statement' type.
- *
  * @since 1.1.0
  */
 public interface Statement extends Node {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/StatementBlock.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/StatementBlock.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/StatementBlock.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/StatementBlock.java
@@ -40,7 +40,6 @@ import org.cqfn.astranaut.core.base.Type;
 
 /**
  * Node that describes the 'StatementBlock' type.
- *
  * @since 1.1.0
  */
 public final class StatementBlock implements Statement {
@@ -110,7 +109,6 @@ public final class StatementBlock implements Statement {
 
     /**
      * Type descriptor of the 'StatementBlock' node.
-     *
      * @since 1.1.0
      */
     private static class TypeImpl implements Type {
@@ -189,7 +187,6 @@ public final class StatementBlock implements Statement {
 
     /**
      * Class for 'StatementBlock' node construction.
-     *
      * @since 1.1.0
      */
     public static final class Constructor implements Builder {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Variable.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Variable.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/Variable.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/Variable.java
@@ -38,7 +38,6 @@ import org.cqfn.astranaut.core.base.Type;
 
 /**
  * Node that describes the 'Variable' type.
- *
  * @since 1.0
  */
 public final class Variable implements AssignableExpression {
@@ -95,7 +94,6 @@ public final class Variable implements AssignableExpression {
 
     /**
      * Type descriptor of the 'Addition' node.
-     *
      * @since 1.0
      */
     private static class TypeImpl implements Type {
@@ -163,7 +161,6 @@ public final class Variable implements AssignableExpression {
 
     /**
      * Class for 'Variable' node construction.
-     *
      * @since 1.0
      */
     public static final class Constructor implements Builder {

--- a/src/test/java/org/cqfn/astranaut/core/example/green/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/green/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/green/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains "green" nodes.
- *
  * @since 1.0
  */
 package org.cqfn.astranaut.core.example.green;

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains "javascript" nodes.
- *
  * @since 1.0
  */
 package org.cqfn.astranaut.core.example.javascript;

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher0.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher0.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher0.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher0.java
@@ -30,7 +30,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Matcher for the subtree returned by the 'js' language parser.
- *
  * @since 1.0
  */
 public final class Matcher0 implements Matcher {

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher1.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher1.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher1.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher1.java
@@ -30,7 +30,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Matcher for the subtree returned by the 'js' language parser.
- *
  * @since 1.0
  */
 public final class Matcher1 implements Matcher {

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher2.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher2.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher2.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Matcher2.java
@@ -30,7 +30,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Matcher for the subtree returned by the 'js' language parser.
- *
  * @since 1.0
  */
 public final class Matcher2 implements Matcher {

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Rule0.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Rule0.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Rule0.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/Rule0.java
@@ -34,7 +34,6 @@ import org.cqfn.astranaut.core.base.Node;
 
 /**
  * Converter describing DSL conversion rule.
- *
  * @since 1.0
  */
 public final class Rule0 implements Converter {

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/javascript/rules/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains rules for "javascript" nodes transformation.
- *
  * @since 1.0
  */
 package org.cqfn.astranaut.core.example.javascript.rules;

--- a/src/test/java/org/cqfn/astranaut/core/example/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/example/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/example/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains example nodes.
- *
  * @since 1.0
  */
 package org.cqfn.astranaut.core.example;

--- a/src/test/java/org/cqfn/astranaut/core/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains tests for core classes.
- *
  * @since 1.0
  */
 package org.cqfn.astranaut.core;

--- a/src/test/java/org/cqfn/astranaut/core/utils/DotRenderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/DotRenderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/utils/DotRenderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/DotRenderTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link DotGenerator} class.
- *
  * @since 1.0.2
  */
 class DotRenderTest {
@@ -45,11 +44,6 @@ class DotRenderTest {
      */
     private static final String DIR = "src/test/resources/visualizer/";
 
-    /**
-     * Test for a single node.
-     *
-     * @throws IOException If input stream cannot be read from a DOT file
-     */
     @Test
     void testSingleNode() throws IOException {
         final Node root = this.createNode("SingleNode");
@@ -58,11 +52,6 @@ class DotRenderTest {
         Assertions.assertEquals(expected, result);
     }
 
-    /**
-     * Test for a single node with data.
-     *
-     * @throws IOException If input stream cannot be read from a DOT file
-     */
     @Test
     void testSingleNodeWithData() throws IOException {
         final Node root = this.createNode("Node", "data");
@@ -73,12 +62,6 @@ class DotRenderTest {
         Assertions.assertEquals(expected, result);
     }
 
-    /**
-     * Test for a node with children.
-     * The tree depth is 2.
-     *
-     * @throws IOException If input stream cannot be read from a DOT file
-     */
     @Test
     void testNodeWithChildren() throws IOException {
         final List<Node> children = new LinkedList<>();
@@ -93,12 +76,6 @@ class DotRenderTest {
         Assertions.assertEquals(expected, result);
     }
 
-    /**
-     * Test for a node with children.
-     * The tree depth is 4.
-     *
-     * @throws IOException If input stream cannot be read from a DOT file
-     */
     @Test
     void testNodeWithNestedChildren() throws IOException {
         final List<Node> thirdl = new LinkedList<>();
@@ -119,11 +96,6 @@ class DotRenderTest {
         Assertions.assertEquals(expected, result);
     }
 
-    /**
-     * Test for a node that contain a null child node.
-     *
-     * @throws IOException If input stream cannot be read from a DOT file
-     */
     @Test
     void testNodeWithNullChild() throws IOException {
         final List<Node> children = new LinkedList<>();
@@ -139,7 +111,6 @@ class DotRenderTest {
 
     /**
      * Renders DOT text from a node.
-     *
      * @param node A tree to be converted
      */
     private String renderDot(final Node node) {

--- a/src/test/java/org/cqfn/astranaut/core/utils/FilesReaderTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/FilesReaderTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/utils/FilesWriterTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/FilesWriterTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/utils/JsonDeserializerTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/JsonDeserializerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/utils/JsonSerializerTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/JsonSerializerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/utils/JsonSerializerTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/JsonSerializerTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test for {@link JsonSerializer} class.
- *
  * @since 1.0.2
  */
 class JsonSerializerTest {
@@ -60,9 +59,6 @@ class JsonSerializerTest {
      */
     private static final Node TEST_NODE_LANG = new TestNodeWithTypeWithLanguage();
 
-    /**
-     * Test for a tree serialization to a JSON string.
-     */
     @Test
     void testSerializationToString() {
         final Tree tree = Tree.createDraft("TestNode<\"value\">");
@@ -73,9 +69,6 @@ class JsonSerializerTest {
         Assertions.assertTrue(result);
     }
 
-    /**
-     * Test for a tree serialization where language is specified.
-     */
     @Test
     void testSerializationWithLanguageSpecified() {
         final Tree tree = new Tree(JsonSerializerTest.TEST_NODE_LANG);
@@ -86,9 +79,6 @@ class JsonSerializerTest {
         Assertions.assertTrue(result);
     }
 
-    /**
-     * Test for a tree serialization where language is specified.
-     */
     @Test
     void testSerializationNestedWithLanguageSpecified() {
         final DraftNode.Constructor ctor = new DraftNode.Constructor();
@@ -102,9 +92,6 @@ class JsonSerializerTest {
         Assertions.assertTrue(result);
     }
 
-    /**
-     * Test for a tree serialization to a JSON string.
-     */
     @Test
     void testSerializationDiffTree() {
         final boolean result = this.serializeAndCompare(
@@ -114,9 +101,6 @@ class JsonSerializerTest {
         Assertions.assertTrue(result);
     }
 
-    /**
-     * Test for a tree serialization to a JSON string.
-     */
     @Test
     void testSerializationPattern() {
         final boolean result = this.serializeAndCompare(
@@ -126,10 +110,6 @@ class JsonSerializerTest {
         Assertions.assertTrue(result);
     }
 
-    /**
-     * Test for a tree serialization to a JSON file.
-     * @param temp A temporary directory
-     */
     @Test
     void testSerializationToFile(@TempDir final Path temp) {
         final Tree tree = this.createSampleTree();
@@ -152,9 +132,6 @@ class JsonSerializerTest {
         Assertions.assertEquals(expected, result);
     }
 
-    /**
-     * Test for exception while writing to a JSON file.
-     */
     @Test
     void testFilesWriterException() {
         final Tree tree = EmptyTree.INSTANCE;

--- a/src/test/java/org/cqfn/astranaut/core/utils/ListUtilsTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/ListUtilsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/utils/ListUtilsTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/ListUtilsTest.java
@@ -31,14 +31,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link ListUtils} class.
- *
  * @since 1.0.2
  */
 class ListUtilsTest {
-    /**
-     * Test adding items to a list that may be null and
-     * creating an unmodifiable list from it.
-     */
     @Test
     void testAddingItems() {
         final ListUtils<Integer> list = new ListUtils<>();

--- a/src/test/java/org/cqfn/astranaut/core/utils/TreeVisualizerTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/TreeVisualizerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/utils/TreeVisualizerTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/TreeVisualizerTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test for {@link TreeVisualizer} class.
- *
  * @since 1.0.2
  */
 class TreeVisualizerTest {

--- a/src/test/java/org/cqfn/astranaut/core/utils/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Ivan Kniazkov
+ * Copyright (c) 2025 Ivan Kniazkov
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/cqfn/astranaut/core/utils/package-info.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/package-info.java
@@ -24,7 +24,6 @@
 
 /**
  * This package contains tests for helper classes.
- *
  * @since 1.0.2
  */
 package org.cqfn.astranaut.core.utils;


### PR DESCRIPTION
If there are multiple inserts that come one after the other, their order is inverted when patching.