### PR TITLE
Fix: The patcher does not always patch files even if the pattern is correct

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '8'
         distribution: 'temurin'

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/DefaultPatcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/DefaultPatcher.java
@@ -23,10 +23,8 @@
  */
 package org.cqfn.astranaut.core.algorithms.patching;
 
-import java.util.Set;
 import org.cqfn.astranaut.core.base.ActionList;
 import org.cqfn.astranaut.core.base.DiffTree;
-import org.cqfn.astranaut.core.base.Node;
 import org.cqfn.astranaut.core.base.Pattern;
 import org.cqfn.astranaut.core.base.Tree;
 
@@ -50,14 +48,13 @@ public final class DefaultPatcher implements Patcher {
     @Override
     public Tree patch(final Tree source, final Pattern pattern) {
         final Matcher matcher = new Matcher(source);
-        final Set<Node> nodes = matcher.match(pattern);
+        final ActionList actions = matcher.match(pattern);
         final Tree result;
-        if (nodes.isEmpty()) {
-            result = source;
-        } else {
-            final ActionList actions = matcher.getActionList();
+        if (actions.hasActions()) {
             final DiffTree diff = actions.convertTreeToDiffTree(source);
             result = diff.getAfter();
+        } else {
+            result = source;
         }
         return result;
     }

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matched.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matched.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Ivan Kniazkov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.cqfn.astranaut.core.algorithms.patching;
+
+import java.util.Map;
+import java.util.TreeMap;
+import org.cqfn.astranaut.core.base.ActionList;
+
+/**
+ * Data obtained through the matching process.
+ * @since 2.0.0
+ */
+final class Matched extends ActionList {
+    /**
+     * Data obtained as a result of hole matching.
+     */
+    private Map<Integer, String> holes;
+
+    /**
+     * Combines data obtained through the matching process.
+     * @param other Other data
+     */
+    void merge(final Matched other) {
+        this.mergeActions(other);
+        if (this.holes == null) {
+            this.holes = other.holes;
+        } else {
+            this.holes.putAll(other.holes);
+        }
+    }
+
+    /**
+     * Checks data matched for a hole. If a hole with the given number is seen for the first time,
+     * stores the data. If it's already known, verifies that the data matches.
+     * @param number Hole number
+     * @param data Matched data
+     * @return Checking result, {@code true} if data is accepted or matches previous,
+     *  {@code false} otherwise.
+     */
+    boolean checkHole(final int number, final String data) {
+        final boolean result;
+        if (this.holes == null) {
+            this.holes = new TreeMap<>();
+            this.holes.put(number, data);
+            result = true;
+        } else if (this.holes.containsKey(number)) {
+            result = this.holes.get(number).equals(data);
+        } else {
+            this.holes.put(number, data);
+            result = true;
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matched.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matched.java
@@ -38,11 +38,24 @@ final class Matched extends ActionList {
     private Map<Integer, String> holes;
 
     /**
+     * Partially clones this object. The new instance will contain only information
+     * about previously extracted holes, without extracted nodes or data.
+     * @return A new Matched object with copied hole data
+     */
+    Matched fork() {
+        final Matched obj = new Matched();
+        if (this.holes != null) {
+            obj.holes = new TreeMap<>(this.holes);
+        }
+        return obj;
+    }
+
+    /**
      * Combines data obtained through the matching process.
      * @param other Other data
      */
     void merge(final Matched other) {
-        this.mergeActions(other);
+        super.merge(other);
         if (this.holes == null) {
             this.holes = other.holes;
         } else {

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
@@ -52,7 +52,7 @@ class Matcher {
     /**
      * List of actions to be performed on the original tree to apply the pattern.
      */
-    private final ActionList actions;
+    private final Matched actions;
 
     /**
      * Constructor.
@@ -60,7 +60,7 @@ class Matcher {
      */
     Matcher(final Tree tree) {
         this.root = tree.getRoot();
-        this.actions = new ActionList();
+        this.actions = new Matched();
     }
 
     /**
@@ -85,7 +85,7 @@ class Matcher {
         );
         final Set<Node> set = new HashSet<>();
         for (final Node node : preset) {
-            final ActionList applicants = new ActionList();
+            final Matched applicants = new Matched();
             final boolean matches = Matcher.checkNode(node, head, applicants);
             if (matches) {
                 set.add(node);
@@ -103,7 +103,7 @@ class Matcher {
      * @return Matching result ({@code true} if matches)
      */
     private static boolean checkNode(
-        final Node node, final Node pattern, final ActionList actions) {
+        final Node node, final Node pattern, final Matched actions) {
         final Node sample;
         final Action action = Action.toAction(pattern);
         if (action instanceof Replace || action instanceof Delete) {
@@ -134,11 +134,11 @@ class Matcher {
      * @return Matching result ({@code true} if matches)
      */
     private static boolean checkChildren(
-        final Node node, final Node sample, final ActionList actions) {
+        final Node node, final Node sample, final Matched actions) {
         final int left = node.getChildCount();
         final int right = sample.getChildCount();
         boolean result = false;
-        final ActionList applicants = new ActionList();
+        final Matched applicants = new Matched();
         for (int index = 0; !result && index < left; index = index + 1) {
             result = true;
             final Iterator<Node> iterator = sample.getIteratorOverChildren();

--- a/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
+++ b/src/main/java/org/cqfn/astranaut/core/algorithms/patching/Matcher.java
@@ -77,16 +77,16 @@ class Matcher {
             node -> node.getTypeName().equals(head.getTypeName())
                 && node.getData().equals(head.getData())
         );
-        final Matched matched = new Matched();
+        final ActionList list = new ActionList();
         for (final Node node : preset) {
             final Matched applicants = new Matched();
             final boolean matches = Matcher.checkNode(node, head, applicants);
             if (matches) {
                 this.found.add(node);
-                matched.merge(applicants);
+                list.merge(applicants);
             }
         }
-        return matched;
+        return list;
     }
 
     /**
@@ -195,7 +195,7 @@ class Matcher {
         final int left = node.getChildCount();
         final int right = sample.getChildCount();
         boolean result = false;
-        final Matched applicants = new Matched();
+        final Matched applicants = matched.fork();
         for (int index = 0; !result && index < left; index = index + 1) {
             result = true;
             final Iterator<Node> iterator = sample.getIteratorOverChildren();

--- a/src/main/java/org/cqfn/astranaut/core/base/ActionList.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/ActionList.java
@@ -139,7 +139,7 @@ public class ActionList {
      * Adds actions from another list to the current list.
      * @param other Another action list
      */
-    protected void mergeActions(final ActionList other) {
+    public void merge(final ActionList other) {
         if (this.insert == null) {
             this.insert = other.insert;
         } else if (other.insert != null) {

--- a/src/main/java/org/cqfn/astranaut/core/base/ActionList.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/ActionList.java
@@ -34,40 +34,31 @@ import org.cqfn.astranaut.core.algorithms.DiffTreeBuilder;
 import org.cqfn.astranaut.core.utils.Promise;
 
 /**
- * List of actions to be added to the tree after deserialization to produce a difference tree.
+ * List of actions to be added to the tree to produce a difference tree.
  * @since 1.1.0
  */
-public final class ActionList {
+public class ActionList {
     /**
      * Collection of nodes to be inserted.
      */
-    private final List<Insertion> insert;
+    private List<Insertion> insert;
 
     /**
      * Collection of nodes to be replaced (node before changes -> node after changes).
      */
-    private final Map<Node, Node> replace;
+    private Map<Node, Node> replace;
 
     /**
      * Set of nodes to be deleted.
      */
-    private final Set<Node> delete;
-
-    /**
-     * Constructor.
-     */
-    public ActionList() {
-        this.insert = new ArrayList<>(0);
-        this.replace = new HashMap<>();
-        this.delete = new HashSet<>();
-    }
+    private Set<Node> delete;
 
     /**
      * Checks if an action is in any list.
      * @return Checking result
      */
     public boolean hasActions() {
-        return !this.insert.isEmpty() || !this.replace.isEmpty() || !this.delete.isEmpty();
+        return this.insert != null || this.replace != null || this.delete != null;
     }
 
     /**
@@ -79,7 +70,7 @@ public final class ActionList {
     @SuppressWarnings("PMD.UselessQualifiedThis")
     public Promise<Node> insertNodeAfter(final Node node, final Node after) {
         return new Promise<>(
-            into -> ActionList.this.insert.add(new Insertion(node, into, after))
+            into -> ActionList.this.insertNodeAfter(node, into, after)
         );
     }
 
@@ -90,6 +81,9 @@ public final class ActionList {
      * @param after Node after which to insert
      */
     public void insertNodeAfter(final Node node, final Node into, final Node after) {
+        if (this.insert == null) {
+            this.insert = new ArrayList<>(1);
+        }
         this.insert.add(new Insertion(node, Objects.requireNonNull(into), after));
     }
 
@@ -99,6 +93,9 @@ public final class ActionList {
      * @param replacement Node to be replaced by
      */
     public void replaceNode(final Node node, final Node replacement) {
+        if (this.replace == null) {
+            this.replace = new HashMap<>();
+        }
         this.replace.put(node, replacement);
     }
 
@@ -107,17 +104,10 @@ public final class ActionList {
      * @param node The node
      */
     public void deleteNode(final Node node) {
+        if (this.delete == null) {
+            this.delete = new HashSet<>();
+        }
         this.delete.add(node);
-    }
-
-    /**
-     * Adds actions from another list to the current list.
-     * @param other Another action list
-     */
-    public void merge(final ActionList other) {
-        this.insert.addAll(other.insert);
-        this.replace.putAll(other.replace);
-        this.delete.addAll(other.delete);
     }
 
     /**
@@ -127,15 +117,43 @@ public final class ActionList {
      */
     public DiffTree convertTreeToDiffTree(final Tree tree) {
         final DiffTreeBuilder builder = new DiffTreeBuilder(tree.getRoot());
-        for (final Insertion insertion : this.insert) {
-            builder.insertNode(insertion);
+        if (this.insert != null) {
+            for (final Insertion insertion : this.insert) {
+                builder.insertNode(insertion);
+            }
         }
-        for (final Map.Entry<Node, Node> pair : this.replace.entrySet()) {
-            builder.replaceNode(pair.getKey(), pair.getValue());
+        if (this.replace != null) {
+            for (final Map.Entry<Node, Node> pair : this.replace.entrySet()) {
+                builder.replaceNode(pair.getKey(), pair.getValue());
+            }
         }
-        for (final Node node : this.delete) {
-            builder.deleteNode(node);
+        if (this.delete != null) {
+            for (final Node node : this.delete) {
+                builder.deleteNode(node);
+            }
         }
         return builder.getDiffTree();
+    }
+
+    /**
+     * Adds actions from another list to the current list.
+     * @param other Another action list
+     */
+    protected void mergeActions(final ActionList other) {
+        if (this.insert == null) {
+            this.insert = other.insert;
+        } else if (other.insert != null) {
+            this.insert.addAll(other.insert);
+        }
+        if (this.replace == null) {
+            this.replace = other.replace;
+        } else if (other.replace != null) {
+            this.replace.putAll(other.replace);
+        }
+        if (this.delete == null) {
+            this.delete = other.delete;
+        } else if (other.delete != null) {
+            this.delete.addAll(other.delete);
+        }
     }
 }

--- a/src/main/java/org/cqfn/astranaut/core/base/DefaultFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DefaultFragment.java
@@ -23,6 +23,7 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import java.util.Objects;
 import org.cqfn.astranaut.core.utils.Pair;
 
 /**
@@ -58,14 +59,6 @@ public final class DefaultFragment implements Fragment {
         this(pair.getKey(), pair.getValue());
     }
 
-    /**
-     * Constructor.
-     * @param positions Positions to calculate bounds from
-     */
-    public DefaultFragment(final Position... positions) {
-        this(Position.bounds(positions));
-    }
-
     @Override
     public Position getBegin() {
         return this.begin;
@@ -74,5 +67,25 @@ public final class DefaultFragment implements Fragment {
     @Override
     public Position getEnd() {
         return this.end;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        final boolean result;
+        if (this == obj) {
+            result = true;
+        } else if (obj instanceof Fragment) {
+            final Fragment other = (Fragment) obj;
+            result = this.begin.equals(other.getBegin())
+                && this.end.equals(other.getEnd());
+        } else {
+            result = false;
+        }
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.begin, this.end);
     }
 }

--- a/src/main/java/org/cqfn/astranaut/core/base/DefaultFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DefaultFragment.java
@@ -88,4 +88,9 @@ public final class DefaultFragment implements Fragment {
     public int hashCode() {
         return Objects.hash(this.begin, this.end);
     }
+
+    @Override
+    public String toString() {
+        return this.getPositionAsString();
+    }
 }

--- a/src/main/java/org/cqfn/astranaut/core/base/DefaultFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DefaultFragment.java
@@ -23,8 +23,10 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import org.cqfn.astranaut.core.utils.Pair;
+
 /**
- * Default implementation of the {@link Position} interface that fits in most cases.
+ * Default implementation of the {@link Fragment} interface that fits in most cases.
  * @since 2.0.0
  */
 public final class DefaultFragment implements Fragment {
@@ -46,6 +48,22 @@ public final class DefaultFragment implements Fragment {
     public DefaultFragment(final Position begin, final Position end) {
         this.begin = begin;
         this.end = end;
+    }
+
+    /**
+     * Constructor.
+     * @param pair Pair of positions (begin, end)
+     */
+    public DefaultFragment(final Pair<Position, Position> pair) {
+        this(pair.getKey(), pair.getValue());
+    }
+
+    /**
+     * Constructor.
+     * @param positions Positions to calculate bounds from
+     */
+    public DefaultFragment(final Position... positions) {
+        this(Position.bounds(positions));
     }
 
     @Override

--- a/src/main/java/org/cqfn/astranaut/core/base/DefaultPosition.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/DefaultPosition.java
@@ -23,6 +23,8 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import java.util.Objects;
+
 /**
  * Default implementation of the {@link Position} interface that fits in most cases.
  * @since 2.0.0
@@ -68,5 +70,26 @@ public final class DefaultPosition implements Position {
     @Override
     public int getColumn() {
         return this.column;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        final boolean result;
+        if (this == obj) {
+            result = true;
+        } else if (obj instanceof Position) {
+            final Position other = (Position) obj;
+            result = this.row == other.getRow()
+                && this.column == other.getColumn()
+                && this.source.equals(other.getSource());
+        } else {
+            result = false;
+        }
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.source, this.row, this.column);
     }
 }

--- a/src/main/java/org/cqfn/astranaut/core/base/EmptyFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/EmptyFragment.java
@@ -23,6 +23,8 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import java.util.Objects;
+
 /**
  * {@code EmptyFragment} is an implementation of {@link Fragment} representing an empty fragment.
  *  It serves as a placeholder when a node does not have an associated fragment
@@ -46,24 +48,17 @@ public final class EmptyFragment implements Fragment {
     };
 
     /**
-     * The position.
+     * Position of the empty fragment.
      */
-    private static final Position POSITION = new Position() {
-        @Override
-        public Source getSource() {
-            return EmptyFragment.SOURCE;
-        }
+    private static final Position POSITION = new EmptyPosition();
 
-        @Override
-        public int getRow() {
-            return 0;
-        }
-
-        @Override
-        public int getColumn() {
-            return 0;
-        }
-    };
+    /**
+     * Hash code of the empty fragment.
+     */
+    private static final int HASH_CODE = Objects.hash(
+        EmptyFragment.POSITION,
+        EmptyFragment.POSITION
+    );
 
     /**
      * Constructor.
@@ -79,5 +74,51 @@ public final class EmptyFragment implements Fragment {
     @Override
     public Position getEnd() {
         return EmptyFragment.POSITION;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return this == obj;
+    }
+
+    @Override
+    public int hashCode() {
+        return EmptyFragment.HASH_CODE;
+    }
+
+    /**
+     * Position that points nowhere.
+     * @since 2.0.0
+     */
+    private static final class EmptyPosition implements Position {
+        /**
+         * Hash code of the empty position.
+         */
+        private static final int HASH_CODE = Objects.hash(EmptyFragment.SOURCE, 0, 0);
+
+        @Override
+        public Source getSource() {
+            return EmptyFragment.SOURCE;
+        }
+
+        @Override
+        public int getRow() {
+            return 0;
+        }
+
+        @Override
+        public int getColumn() {
+            return 0;
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            return this == obj;
+        }
+
+        @Override
+        public int hashCode() {
+            return EmptyPosition.HASH_CODE;
+        }
     }
 }

--- a/src/main/java/org/cqfn/astranaut/core/base/EmptyFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/EmptyFragment.java
@@ -86,6 +86,11 @@ public final class EmptyFragment implements Fragment {
         return EmptyFragment.HASH_CODE;
     }
 
+    @Override
+    public String toString() {
+        return "\u2205";
+    }
+
     /**
      * Position that points nowhere.
      * @since 2.0.0

--- a/src/main/java/org/cqfn/astranaut/core/base/Fragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Fragment.java
@@ -23,10 +23,14 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes a fragment of source code.
  * @since 1.0
  */
+@SuppressWarnings("PMD.ProhibitPublicStaticMethods")
 public interface Fragment {
     /**
      * Returns the first position of the fragment.
@@ -74,6 +78,74 @@ public interface Fragment {
                 end.getRow(),
                 end.getColumn()
             );
+        }
+        return result;
+    }
+
+    /**
+     * Creates a fragment from one or more positions.
+     *  Returns an empty fragment if none provided, a single-point fragment if one,
+     *  or a range fragment if multiple. Regardless of input order, the earliest and
+     *  latest positions are used to form a correct fragment.
+     * @param positions Positions to build fragment from
+     * @return Corresponding fragment instance
+     */
+    static Fragment fromPositions(final Position... positions) {
+        final Fragment fragment;
+        if (positions.length == 0) {
+            fragment = EmptyFragment.INSTANCE;
+        } else if (positions.length == 1) {
+            fragment = new DefaultFragment(positions[0], positions[0]);
+        } else {
+            fragment = new DefaultFragment(Position.bounds(positions));
+        }
+        return fragment;
+    }
+
+    /**
+     * Creates a fragment from one or more positions.
+     *  Returns an empty fragment if none provided, a single-point fragment if one,
+     *  or a range fragment if multiple. Regardless of input order, the earliest and
+     *  latest positions are used to form a correct fragment.
+     * @param positions List of positions to build fragment from
+     * @return Corresponding fragment instance
+     */
+    static Fragment fromPositions(final List<Position> positions) {
+        final Fragment result;
+        if (positions.isEmpty()) {
+            result = EmptyFragment.INSTANCE;
+        } else if (positions.size() == 1) {
+            result = new DefaultFragment(positions.get(0), positions.get(0));
+        } else {
+            result = new DefaultFragment(Position.bounds(positions));
+        }
+        return result;
+    }
+
+    /**
+     * Creates a fragment that spans all given nodes.
+     *  Returns an empty fragment if the list is empty, or the fragment of the single node
+     *  if there's only one. For multiple nodes, uses the earliest and latest positions
+     *  (ignoring nodes with empty fragments) to create a proper range.
+     * @param nodes List of nodes
+     * @return Combined fragment covering the given nodes
+     */
+    static Fragment fromNodes(final List<Node> nodes) {
+        final Fragment result;
+        if (nodes.isEmpty()) {
+            result = EmptyFragment.INSTANCE;
+        } else if (nodes.size() == 1) {
+            result = nodes.get(0).getFragment();
+        } else {
+            final List<Position> positions = new ArrayList<>(nodes.size());
+            for (final Node node : nodes) {
+                final Fragment fragment = node.getFragment();
+                if (!fragment.equals(EmptyFragment.INSTANCE)) {
+                    positions.add(fragment.getBegin());
+                    positions.add(fragment.getEnd());
+                }
+            }
+            result = Fragment.fromPositions(positions);
         }
         return result;
     }

--- a/src/main/java/org/cqfn/astranaut/core/base/Fragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Fragment.java
@@ -56,7 +56,7 @@ public interface Fragment {
      * Returns a formatted string representing the position of the fragment.
      * @return A formatted string describing the position of the fragment
      */
-    default String getPosition() {
+    default String getPositionAsString() {
         final String result;
         final Position begin = this.getBegin();
         final Position end = this.getEnd();

--- a/src/main/java/org/cqfn/astranaut/core/base/Position.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Position.java
@@ -23,6 +23,7 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import java.util.List;
 import org.cqfn.astranaut.core.utils.Pair;
 
 /**
@@ -32,6 +33,7 @@ import org.cqfn.astranaut.core.utils.Pair;
  *  have different sources, they are considered incomparable.
  * @since 1.0
  */
+@SuppressWarnings("PMD.ProhibitPublicStaticMethods")
 public interface Position extends Comparable<Position> {
 
     /**
@@ -73,7 +75,6 @@ public interface Position extends Comparable<Position> {
      * @return Pair of first and last position (by order)
      * @throws IllegalArgumentException If no positions are provided or sources differ
      */
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     static Pair<Position, Position> bounds(final Position... positions) {
         if (positions.length == 0) {
             throw new IllegalArgumentException();
@@ -82,6 +83,30 @@ public interface Position extends Comparable<Position> {
         Position last = positions[0];
         for (int index = 1; index < positions.length; index = index + 1) {
             final Position position = positions[index];
+            if (position.compareTo(first) < 0) {
+                first = position;
+            }
+            if (position.compareTo(last) > 0) {
+                last = position;
+            }
+        }
+        return new Pair<>(first, last);
+    }
+
+    /**
+     * Returns the first and last position from the given list of positions.
+     * @param positions List of Position objects
+     * @return Pair of first and last position (by order)
+     * @throws IllegalArgumentException If list is empty or sources differ
+     */
+    static Pair<Position, Position> bounds(final List<Position> positions) {
+        if (positions.isEmpty()) {
+            throw new IllegalArgumentException();
+        }
+        Position first = positions.get(0);
+        Position last = positions.get(0);
+        for (int index = 1; index < positions.size(); index = index + 1) {
+            final Position position = positions.get(index);
             if (position.compareTo(first) < 0) {
                 first = position;
             }

--- a/src/main/java/org/cqfn/astranaut/core/base/Position.java
+++ b/src/main/java/org/cqfn/astranaut/core/base/Position.java
@@ -23,6 +23,8 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import org.cqfn.astranaut.core.utils.Pair;
+
 /**
  * Represents a position in source code.
  *  It provides methods to retrieve the source, row, and column of the position.
@@ -34,18 +36,21 @@ public interface Position extends Comparable<Position> {
 
     /**
      * Returns an object representing the source code that has this position.
+     *
      * @return Object representing the source code
      */
     Source getSource();
 
     /**
      * Returns the row (line) number of this position.
+     *
      * @return The row number
      */
     int getRow();
 
     /**
      * Returns the column number of this position.
+     *
      * @return The column number
      */
     int getColumn();
@@ -60,5 +65,30 @@ public interface Position extends Comparable<Position> {
             result = Integer.compare(this.getColumn(), other.getColumn());
         }
         return result;
+    }
+
+    /**
+     * Returns the first and last position from the given list of positions.
+     * @param positions Vararg of Position objects
+     * @return Pair of first and last position (by order)
+     * @throws IllegalArgumentException If no positions are provided or sources differ
+     */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    static Pair<Position, Position> bounds(final Position... positions) {
+        if (positions.length == 0) {
+            throw new IllegalArgumentException();
+        }
+        Position first = positions[0];
+        Position last = positions[0];
+        for (int index = 1; index < positions.length; index = index + 1) {
+            final Position position = positions[index];
+            if (position.compareTo(first) < 0) {
+                first = position;
+            }
+            if (position.compareTo(last) > 0) {
+                last = position;
+            }
+        }
+        return new Pair<>(first, last);
     }
 }

--- a/src/main/java/org/cqfn/astranaut/core/utils/parsing/CharFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/parsing/CharFragment.java
@@ -77,4 +77,25 @@ class CharFragment implements Fragment {
     public int hashCode() {
         return Objects.hash(this.position, this.position);
     }
+
+    @Override
+    public String toString() {
+        final String result;
+        final String path = this.position.getSource().getFileName();
+        if (path.isEmpty()) {
+            result = String.format(
+                "%d.%d",
+                this.position.getRow(),
+                this.position.getColumn()
+            );
+        } else {
+            result = String.format(
+                "%s, %d.%d",
+                path,
+                this.position.getRow(),
+                this.position.getColumn()
+            );
+        }
+        return result;
+    }
 }

--- a/src/main/java/org/cqfn/astranaut/core/utils/parsing/CharFragment.java
+++ b/src/main/java/org/cqfn/astranaut/core/utils/parsing/CharFragment.java
@@ -23,6 +23,7 @@
  */
 package org.cqfn.astranaut.core.utils.parsing;
 
+import java.util.Objects;
 import org.cqfn.astranaut.core.base.Fragment;
 import org.cqfn.astranaut.core.base.Position;
 
@@ -55,5 +56,25 @@ class CharFragment implements Fragment {
     @Override
     public Position getEnd() {
         return this.position;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        final boolean result;
+        if (this == obj) {
+            result = true;
+        } else if (obj instanceof Fragment) {
+            final Fragment other = (Fragment) obj;
+            result = this.position.equals(other.getBegin())
+                && this.position.equals(other.getEnd());
+        } else {
+            result = false;
+        }
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.position, this.position);
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/MatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/MatcherTest.java
@@ -49,7 +49,8 @@ class MatcherTest {
         final DiffNode subtree = new DiffNode(DraftNode.create("A(B,C)"));
         final Pattern pattern = new Pattern(new PatternNode(subtree));
         final Matcher matcher = new Matcher(tree);
-        final Set<Node> found = matcher.match(pattern);
+        matcher.match(pattern);
+        final Set<Node> found = matcher.getFoundNodes();
         Assertions.assertEquals(2, found.size());
         for (final Node node : found) {
             Assertions.assertEquals("A", node.getTypeName());
@@ -64,7 +65,8 @@ class MatcherTest {
         );
         final Matcher matcher = new Matcher(tree);
         final Pattern pattern = new Pattern(new PatternNode(subtree));
-        final Set<Node> found = matcher.match(pattern);
+        matcher.match(pattern);
+        final Set<Node> found = matcher.getFoundNodes();
         Assertions.assertEquals(1, found.size());
         final Node node = found.iterator().next();
         Assertions.assertEquals("A", node.getTypeName());
@@ -86,7 +88,8 @@ class MatcherTest {
         final Pattern pattern = new Pattern(new PatternNode(builder.getDiffTree().getRoot()));
         final Tree tree = Tree.createDraft("X(Y,A(B),Z)");
         final Matcher matcher = new Matcher(tree);
-        final Set<Node> found = matcher.match(pattern);
+        matcher.match(pattern);
+        final Set<Node> found = matcher.getFoundNodes();
         Assertions.assertEquals(1, found.size());
         final Node node = found.iterator().next();
         Assertions.assertEquals("A", node.getTypeName());
@@ -101,7 +104,8 @@ class MatcherTest {
         final Pattern pattern = new Pattern(new PatternNode(builder.getDiffTree().getRoot()));
         final Tree tree = Tree.createDraft("X(Y,A(B,D),Z)");
         final Matcher matcher = new Matcher(tree);
-        final Set<Node> found = matcher.match(pattern);
+        matcher.match(pattern);
+        final Set<Node> found = matcher.getFoundNodes();
         Assertions.assertEquals(1, found.size());
         final Node node = found.iterator().next();
         Assertions.assertEquals("A", node.getTypeName());
@@ -116,7 +120,8 @@ class MatcherTest {
         final Pattern pattern = new Pattern(new PatternNode(builder.getDiffTree().getRoot()));
         final Tree tree = Tree.createDraft("X(Y,A(B,D),Z)");
         final Matcher matcher = new Matcher(tree);
-        final Set<Node> found = matcher.match(pattern);
+        matcher.match(pattern);
+        final Set<Node> found = matcher.getFoundNodes();
         Assertions.assertEquals(1, found.size());
         final Node node = found.iterator().next();
         Assertions.assertEquals("A", node.getTypeName());
@@ -134,7 +139,8 @@ class MatcherTest {
         final Pattern pattern = pbuilder.getPattern();
         final Tree tree = Tree.createDraft("X(Y,A(B,D<\"11\">),Z)");
         final Matcher matcher = new Matcher(tree);
-        final Set<Node> found = matcher.match(pattern);
+        matcher.match(pattern);
+        final Set<Node> found = matcher.getFoundNodes();
         Assertions.assertEquals(1, found.size());
         final Node node = found.iterator().next();
         Assertions.assertEquals("A", node.getTypeName());
@@ -151,7 +157,8 @@ class MatcherTest {
         );
         final Tree tree = Tree.createDraft("X(Y, A(B<\"test\">), Z)");
         final Matcher matcher = new Matcher(tree);
-        final Set<Node> found = matcher.match(pattern);
+        matcher.match(pattern);
+        final Set<Node> found = matcher.getFoundNodes();
         Assertions.assertEquals(1, found.size());
     }
 
@@ -166,7 +173,8 @@ class MatcherTest {
         );
         final Tree tree = Tree.createDraft("X(Y,A(B,C),Z)");
         final Matcher matcher = new Matcher(tree);
-        final Set<Node> found = matcher.match(pattern);
+        matcher.match(pattern);
+        final Set<Node> found = matcher.getFoundNodes();
         Assertions.assertEquals(0, found.size());
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/MatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/MatcherTest.java
@@ -28,6 +28,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import org.cqfn.astranaut.core.algorithms.DiffTreeBuilder;
 import org.cqfn.astranaut.core.algorithms.PatternBuilder;
+import org.cqfn.astranaut.core.algorithms.mapping.TopDownMapper;
+import org.cqfn.astranaut.core.base.ActionList;
 import org.cqfn.astranaut.core.base.DiffNode;
 import org.cqfn.astranaut.core.base.DraftNode;
 import org.cqfn.astranaut.core.base.Insertion;
@@ -176,5 +178,29 @@ class MatcherTest {
         matcher.match(pattern);
         final Set<Node> found = matcher.getFoundNodes();
         Assertions.assertEquals(0, found.size());
+    }
+
+    @Test
+    void mathEmptyNodeAndPatternWithReplacement() {
+        final Tree before = Tree.createDraft("X(A(B))");
+        final Tree after = Tree.createDraft("X(A(C,D))");
+        final DiffTreeBuilder builder = new DiffTreeBuilder(before);
+        builder.build(after, TopDownMapper.INSTANCE);
+        final Pattern pattern = new Pattern(new PatternNode(builder.getDiffTree().getRoot()));
+        final Matcher matcher = new Matcher(Tree.createDraft("X(A())"));
+        final ActionList list = matcher.match(pattern);
+        Assertions.assertFalse(list.hasActions());
+    }
+
+    @Test
+    void mathEmptyNodeAndPatternWithThreeInsertions() {
+        final Tree before = Tree.createDraft("X(Y())");
+        final Tree after = Tree.createDraft("X(Y(A,B,C))");
+        final DiffTreeBuilder builder = new DiffTreeBuilder(before);
+        builder.build(after, TopDownMapper.INSTANCE);
+        final Pattern pattern = new Pattern(new PatternNode(builder.getDiffTree().getRoot()));
+        final Matcher matcher = new Matcher(Tree.createDraft("X(Y())"));
+        final ActionList list = matcher.match(pattern);
+        Assertions.assertTrue(list.hasActions());
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.Test;
  * Testing {@link Patcher} class.
  * @since 1.1.5
  */
+@SuppressWarnings("PMD.TooManyMethods")
 class PatcherTest {
     @Test
     void patchingByPatternThatDoesNotMatch() {
@@ -250,6 +251,20 @@ class PatcherTest {
     void mineAndPatchInsertionToEmpty() {
         final Tree before = Tree.createDraft("X(Y())");
         final Tree after = Tree.createDraft("X(Y(Z))");
+        final Mapper mapper = TopDownMapper.INSTANCE;
+        final DiffTreeBuilder builder = new DiffTreeBuilder(before);
+        builder.build(after, mapper);
+        final DiffTree diff = builder.getDiffTree();
+        final Pattern pattern = new PatternBuilder(diff).getPattern();
+        final Patcher patcher = DefaultPatcher.INSTANCE;
+        final Tree patched = patcher.patch(before, pattern);
+        Assertions.assertTrue(after.deepCompare(patched));
+    }
+
+    @Test
+    void mineAndPatchSixActions() {
+        final Tree before = Tree.createDraft("X(Y(B,A,C,A),Z(B,A,C,A))");
+        final Tree after = Tree.createDraft("X(Y(A,E,A,D),Z(A,E,A,D))");
         final Mapper mapper = TopDownMapper.INSTANCE;
         final DiffTreeBuilder builder = new DiffTreeBuilder(before);
         builder.build(after, mapper);

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
@@ -278,4 +278,52 @@ class PatcherTest {
         final Tree patched = patcher.patch(before, pattern);
         Assertions.assertTrue(after.deepCompare(patched));
     }
+
+    @Test
+    void mineAndPatchWithHoles() {
+        final Map<String, Set<Node>> nodes = new TreeMap<>();
+        final Tree before = Tree.createDraft(
+            "X(Y(A<'a'>,B,C),Z(A<'a'>,B,C))",
+            nodes
+        );
+        final Tree after = Tree.createDraft("X(Y(A<'a'>,B,D),Z(A<'a'>,B))");
+        final Mapper mapper = TopDownMapper.INSTANCE;
+        final DiffTreeBuilder diffbuilder = new DiffTreeBuilder(before);
+        diffbuilder.build(after, mapper);
+        final DiffTree diff = diffbuilder.getDiffTree();
+        final PatternBuilder patbuilder = new PatternBuilder(diff);
+        for (final Node node : nodes.get("A")) {
+            patbuilder.makeHole(node, 1);
+        }
+        for (final Node node : nodes.get("B")) {
+            patbuilder.makeHole(node, 2);
+        }
+        final Pattern pattern = patbuilder.getPattern();
+        final Patcher patcher = DefaultPatcher.INSTANCE;
+        final Tree patched = patcher.patch(before, pattern);
+        Assertions.assertTrue(after.deepCompare(patched));
+    }
+
+    @Test
+    void mineAndPatchWithMismatchedHoles() {
+        final Map<String, Set<Node>> nodes = new TreeMap<>();
+        final Tree before = Tree.createDraft(
+            "X(Y(A<'a'>,B,C),Z(A<'q'>,B,C))",
+            nodes
+        );
+        final Tree after = Tree.createDraft("X(Y(A<'a'>,B,D),Z(A<'q'>,B))");
+        final Mapper mapper = TopDownMapper.INSTANCE;
+        final DiffTreeBuilder diffbuilder = new DiffTreeBuilder(before);
+        diffbuilder.build(after, mapper);
+        final DiffTree diff = diffbuilder.getDiffTree();
+        final PatternBuilder patbuilder = new PatternBuilder(diff);
+        for (final Node node : nodes.get("A")) {
+            patbuilder.makeHole(node, 1);
+        }
+        final Pattern pattern = patbuilder.getPattern();
+        final Patcher patcher = DefaultPatcher.INSTANCE;
+        final Tree patched = patcher.patch(before, pattern);
+        Assertions.assertFalse(after.deepCompare(patched));
+        Assertions.assertTrue(before.deepCompare(patched));
+    }
 }

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
@@ -48,6 +48,7 @@ import org.cqfn.astranaut.core.example.green.IntegerLiteral;
 import org.cqfn.astranaut.core.example.green.SimpleAssignment;
 import org.cqfn.astranaut.core.example.green.Variable;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -244,5 +245,20 @@ class PatcherTest {
         final Tree patched = patcher.patch(original, pattern);
         final Tree expected = Tree.createDraft("Y(X(Z,A,B,C,D),E,F)");
         Assertions.assertEquals(expected.toString(), patched.toString());
+    }
+
+    @Test
+    @Disabled
+    void mineAndPatchInsertionToEmpty() {
+        final Tree before = Tree.createDraft("X(Y())");
+        final Tree after = Tree.createDraft("X(Y(Z))");
+        final Mapper mapper = TopDownMapper.INSTANCE;
+        final DiffTreeBuilder builder = new DiffTreeBuilder(before);
+        builder.build(after, mapper);
+        final DiffTree diff = builder.getDiffTree();
+        final Pattern pattern = new PatternBuilder(diff).getPattern();
+        final Patcher patcher = DefaultPatcher.INSTANCE;
+        final Tree patched = patcher.patch(before, pattern);
+        Assertions.assertTrue(after.deepCompare(patched));
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
@@ -262,12 +262,12 @@ class PatcherTest {
     }
 
     @Test
-    void mineAndPatchEightActions() {
+    void mineAndPatchTenActions() {
         final Tree before = Tree.createDraft(
-            "X(Y(B,A,C,A),Z(B,A,C,A),W(A,B),V(A,B))"
+            "X(Y(B,A,C,A),Z(B,A,C,A),W(A,B),V(A,B),U(A,B))"
         );
         final Tree after = Tree.createDraft(
-            "X(Y(A,E,A,D),Z(A,E,A,D),W(C,D),V(A,B)"
+            "X(Y(A,E,A,D),Z(A,E,A,D),W(C,D),V(A,B),U()"
         );
         final Mapper mapper = TopDownMapper.INSTANCE;
         final DiffTreeBuilder builder = new DiffTreeBuilder(before);

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
@@ -262,9 +262,13 @@ class PatcherTest {
     }
 
     @Test
-    void mineAndPatchSixActions() {
-        final Tree before = Tree.createDraft("X(Y(B,A,C,A),Z(B,A,C,A))");
-        final Tree after = Tree.createDraft("X(Y(A,E,A,D),Z(A,E,A,D))");
+    void mineAndPatchEightActions() {
+        final Tree before = Tree.createDraft(
+            "X(Y(B,A,C,A),Z(B,A,C,A),W(A,B),V(A,B))"
+        );
+        final Tree after = Tree.createDraft(
+            "X(Y(A,E,A,D),Z(A,E,A,D),W(C,D),V(A,B)"
+        );
         final Mapper mapper = TopDownMapper.INSTANCE;
         final DiffTreeBuilder builder = new DiffTreeBuilder(before);
         builder.build(after, mapper);

--- a/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/algorithms/patching/PatcherTest.java
@@ -48,7 +48,6 @@ import org.cqfn.astranaut.core.example.green.IntegerLiteral;
 import org.cqfn.astranaut.core.example.green.SimpleAssignment;
 import org.cqfn.astranaut.core.example.green.Variable;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -248,7 +247,6 @@ class PatcherTest {
     }
 
     @Test
-    @Disabled
     void mineAndPatchInsertionToEmpty() {
         final Tree before = Tree.createDraft("X(Y())");
         final Tree after = Tree.createDraft("X(Y(Z))");

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
@@ -107,6 +107,20 @@ class DefaultFragmentTest {
         );
         Assertions.assertEquals(1, third.getBegin().getRow());
         Assertions.assertEquals(2, third.getEnd().getRow());
+        final Fragment fourth = Fragment.fromPositions(
+            Arrays.asList(
+                new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 1),
+                new DefaultPosition(DefaultFragmentTest.SOURCE, 2, 1)
+            )
+        );
+        Assertions.assertEquals(fourth, third);
+        final Fragment other = Fragment.fromPositions(
+            Arrays.asList(
+                new DefaultPosition(DefaultFragmentTest.SOURCE, 3, 1),
+                new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 1)
+            )
+        );
+        Assertions.assertNotEquals(other, third);
     }
 
     @Test

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
@@ -115,6 +115,7 @@ class DefaultFragmentTest {
         final Fragment third = Fragment.fromNodes(
             Arrays.asList(
                 new FakeNode(3),
+                new FakeNode(0),
                 new FakeNode(2),
                 new FakeNode(1)
             )
@@ -143,9 +144,13 @@ class DefaultFragmentTest {
 
         @Override
         public Fragment getFragment() {
-            return Fragment.fromPositions(
-                new DefaultPosition(DefaultFragmentTest.SOURCE, this.row, 1)
-            );
+            Fragment fragment = EmptyFragment.INSTANCE;
+            if (this.row != 0) {
+                fragment = Fragment.fromPositions(
+                    new DefaultPosition(DefaultFragmentTest.SOURCE, this.row, 1)
+                );
+            }
+            return fragment;
         }
 
         @Override

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
@@ -23,6 +23,8 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import java.util.Arrays;
+import java.util.Collections;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -31,11 +33,15 @@ import org.junit.jupiter.api.Test;
  * @since 2.0.0
  */
 class DefaultFragmentTest {
+    /**
+     * Fake source for testing purposes.
+     */
+    private static final Source SOURCE = (start, end) -> "";
+
     @Test
     void testBaseInterface() {
-        final Source source = (start, end) -> "";
-        final Position begin = new DefaultPosition(source, 1, 1);
-        final Position end = new DefaultPosition(source, 1, 2);
+        final Position begin = new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 1);
+        final Position end = new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 2);
         final Fragment fragment = new DefaultFragment(begin, end);
         Assertions.assertSame(begin, fragment.getBegin());
         Assertions.assertSame(end, fragment.getEnd());
@@ -43,18 +49,128 @@ class DefaultFragmentTest {
 
     @Test
     void testAlternativeConstructors() {
-        final Source source = (start, end) -> "";
         final Position[] positions = {
-            new DefaultPosition(source, 4, 7),
-            new DefaultPosition(source, 1, 2),
-            new DefaultPosition(source, 3, 14),
-            new DefaultPosition(source, 2, 1),
+            new DefaultPosition(DefaultFragmentTest.SOURCE, 4, 7),
+            new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 2),
+            new DefaultPosition(DefaultFragmentTest.SOURCE, 3, 14),
+            new DefaultPosition(DefaultFragmentTest.SOURCE, 2, 1),
         };
         Fragment fragment = Fragment.fromPositions(positions);
         Assertions.assertEquals(1, fragment.getBegin().getRow());
         Assertions.assertEquals(4, fragment.getEnd().getRow());
-        fragment = Fragment.fromPositions(new DefaultPosition(source, 13, 13));
+        fragment = Fragment.fromPositions(
+            new DefaultPosition(DefaultFragmentTest.SOURCE, 13, 13)
+        );
         Assertions.assertEquals(13, fragment.getBegin().getRow());
         Assertions.assertEquals(13, fragment.getEnd().getRow());
+    }
+
+    @Test
+    void fromArrayOfPositions() {
+        final Fragment first = Fragment.fromPositions();
+        Assertions.assertEquals(EmptyFragment.INSTANCE, first);
+        final Fragment second = Fragment.fromPositions(
+            new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 1)
+        );
+        Assertions.assertEquals(1, second.getBegin().getRow());
+        Assertions.assertEquals(1, second.getEnd().getRow());
+        final Fragment third = Fragment.fromPositions(
+            new DefaultPosition(DefaultFragmentTest.SOURCE, 2, 1),
+            new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 1)
+        );
+        Assertions.assertEquals(1, third.getBegin().getRow());
+        Assertions.assertEquals(2, third.getEnd().getRow());
+    }
+
+    @Test
+    void fromListOfPositions() {
+        final Fragment first = Fragment.fromPositions(Collections.emptyList());
+        Assertions.assertEquals(EmptyFragment.INSTANCE, first);
+        final Fragment second = Fragment.fromPositions(
+            Collections.singletonList(
+                new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 1)
+            )
+        );
+        Assertions.assertEquals(1, second.getBegin().getRow());
+        Assertions.assertEquals(1, second.getEnd().getRow());
+        final Fragment third = Fragment.fromPositions(
+            Arrays.asList(
+                new DefaultPosition(DefaultFragmentTest.SOURCE, 2, 1),
+                new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 1)
+            )
+        );
+        Assertions.assertEquals(1, third.getBegin().getRow());
+        Assertions.assertEquals(2, third.getEnd().getRow());
+    }
+
+    @Test
+    void fromListOfNodes() {
+        final Fragment first = Fragment.fromNodes(Collections.emptyList());
+        Assertions.assertEquals(EmptyFragment.INSTANCE, first);
+        final Fragment second = Fragment.fromNodes(
+            Collections.singletonList(new FakeNode(1))
+        );
+        Assertions.assertEquals(1, second.getBegin().getRow());
+        Assertions.assertEquals(1, second.getEnd().getRow());
+        final Fragment third = Fragment.fromNodes(
+            Arrays.asList(
+                new FakeNode(3),
+                new FakeNode(2),
+                new FakeNode(1)
+            )
+        );
+        Assertions.assertEquals(1, third.getBegin().getRow());
+        Assertions.assertEquals(3, third.getEnd().getRow());
+    }
+
+    /**
+     * A fake node for test purposes, it only returns a fragment.
+     * @since 2.0.0
+     */
+    private static final class FakeNode extends NodeAndType {
+        /**
+         * Row number.
+         */
+        private final int row;
+
+        /**
+         * Constructor.
+         * @param row Row number
+         */
+        private FakeNode(final int row) {
+            this.row = row;
+        }
+
+        @Override
+        public Fragment getFragment() {
+            return Fragment.fromPositions(
+                new DefaultPosition(DefaultFragmentTest.SOURCE, this.row, 1)
+            );
+        }
+
+        @Override
+        public String getData() {
+            return "";
+        }
+
+        @Override
+        public int getChildCount() {
+            return 0;
+        }
+
+        @Override
+        public Node getChild(final int index) {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return "X";
+        }
+
+        @Override
+        public Builder createBuilder() {
+            return null;
+        }
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
@@ -50,10 +50,10 @@ class DefaultFragmentTest {
             new DefaultPosition(source, 3, 14),
             new DefaultPosition(source, 2, 1),
         };
-        Fragment fragment = new DefaultFragment(positions);
+        Fragment fragment = Fragment.fromPositions(positions);
         Assertions.assertEquals(1, fragment.getBegin().getRow());
         Assertions.assertEquals(4, fragment.getEnd().getRow());
-        fragment = new DefaultFragment(new DefaultPosition(source, 13, 13));
+        fragment = Fragment.fromPositions(new DefaultPosition(source, 13, 13));
         Assertions.assertEquals(13, fragment.getBegin().getRow());
         Assertions.assertEquals(13, fragment.getEnd().getRow());
     }

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
@@ -40,4 +40,21 @@ class DefaultFragmentTest {
         Assertions.assertSame(begin, fragment.getBegin());
         Assertions.assertSame(end, fragment.getEnd());
     }
+
+    @Test
+    void testAlternativeConstructors() {
+        final Source source = (start, end) -> "";
+        final Position[] positions = {
+            new DefaultPosition(source, 4, 7),
+            new DefaultPosition(source, 1, 2),
+            new DefaultPosition(source, 3, 14),
+            new DefaultPosition(source, 2, 1),
+        };
+        Fragment fragment = new DefaultFragment(positions);
+        Assertions.assertEquals(1, fragment.getBegin().getRow());
+        Assertions.assertEquals(4, fragment.getEnd().getRow());
+        fragment = new DefaultFragment(new DefaultPosition(source, 13, 13));
+        Assertions.assertEquals(13, fragment.getBegin().getRow());
+        Assertions.assertEquals(13, fragment.getEnd().getRow());
+    }
 }

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultFragmentTest.java
@@ -45,6 +45,11 @@ class DefaultFragmentTest {
         final Fragment fragment = new DefaultFragment(begin, end);
         Assertions.assertSame(begin, fragment.getBegin());
         Assertions.assertSame(end, fragment.getEnd());
+        Assertions.assertTrue(fragment.equals(fragment));
+        Assertions.assertNotEquals(0, fragment.hashCode());
+        final Fragment other = new DefaultFragment(begin, end);
+        Assertions.assertEquals(fragment, other);
+        Assertions.assertNotEquals(fragment, DummyNode.INSTANCE);
     }
 
     @Test
@@ -72,6 +77,7 @@ class DefaultFragmentTest {
         final Fragment second = Fragment.fromPositions(
             new DefaultPosition(DefaultFragmentTest.SOURCE, 1, 1)
         );
+        Assertions.assertNotEquals(EmptyFragment.INSTANCE, second);
         Assertions.assertEquals(1, second.getBegin().getRow());
         Assertions.assertEquals(1, second.getEnd().getRow());
         final Fragment third = Fragment.fromPositions(

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultPositionTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultPositionTest.java
@@ -33,11 +33,14 @@ import org.junit.jupiter.api.Test;
 class DefaultPositionTest {
     @Test
     void testBaseInterface() {
-        final Source source = (start, end) -> "";
-        final Position position = new DefaultPosition(source, 1, 2);
-        Assertions.assertSame(source, position.getSource());
+        final Source alpha = (start, end) -> "";
+        final Position position = new DefaultPosition(alpha, 1, 2);
+        Assertions.assertSame(alpha, position.getSource());
         Assertions.assertEquals(1, position.getRow());
         Assertions.assertEquals(2, position.getColumn());
         Assertions.assertNotEquals(position, DummyNode.INSTANCE);
+        final Source beta = (start, end) -> "abc";
+        final Position other = new DefaultPosition(beta, 1, 2);
+        Assertions.assertNotEquals(position, other);
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/base/DefaultPositionTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/DefaultPositionTest.java
@@ -38,5 +38,6 @@ class DefaultPositionTest {
         Assertions.assertSame(source, position.getSource());
         Assertions.assertEquals(1, position.getRow());
         Assertions.assertEquals(2, position.getColumn());
+        Assertions.assertNotEquals(position, DummyNode.INSTANCE);
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/base/EmptyFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/EmptyFragmentTest.java
@@ -45,5 +45,6 @@ class EmptyFragmentTest {
         Assertions.assertNotEquals(begin, other);
         Assertions.assertNotEquals(end, other);
         Assertions.assertNotEquals(0, EmptyFragment.INSTANCE.hashCode());
+        Assertions.assertEquals("\u2205", EmptyFragment.INSTANCE.toString());
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/base/EmptyFragmentTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/EmptyFragmentTest.java
@@ -35,10 +35,15 @@ class EmptyFragmentTest {
     void testBaseInterface() {
         final Position begin = EmptyFragment.INSTANCE.getBegin();
         final Position end = EmptyFragment.INSTANCE.getEnd();
+        Assertions.assertEquals(begin, end);
         Assertions.assertEquals("", EmptyFragment.INSTANCE.getCode());
         Assertions.assertEquals(0, begin.getRow());
         Assertions.assertEquals(0, begin.getColumn());
         Assertions.assertEquals(0, end.getRow());
         Assertions.assertEquals(0, end.getColumn());
+        final Position other = new DefaultPosition((first, second) -> "", 1, 1);
+        Assertions.assertNotEquals(begin, other);
+        Assertions.assertNotEquals(end, other);
+        Assertions.assertNotEquals(0, EmptyFragment.INSTANCE.hashCode());
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/base/PositionTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/PositionTest.java
@@ -23,6 +23,8 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import java.util.Arrays;
+import java.util.Collections;
 import org.cqfn.astranaut.core.utils.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -48,6 +50,10 @@ class PositionTest {
     @Test
     void testBounds() {
         Assertions.assertThrows(IllegalArgumentException.class, Position::bounds);
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> Position.bounds(Collections.emptyList())
+        );
         final Source source = (start, end) -> "";
         final Position[] list = {
             new DefaultPosition(source, 2, 2),
@@ -55,7 +61,10 @@ class PositionTest {
             new DefaultPosition(source, 4, 4),
             new DefaultPosition(source, 3, 3),
         };
-        final Pair<Position, Position> pair = Position.bounds(list);
+        Pair<Position, Position> pair = Position.bounds(list);
+        Assertions.assertEquals(1, pair.getKey().getRow());
+        Assertions.assertEquals(4, pair.getValue().getRow());
+        pair = Position.bounds(Arrays.asList(list));
         Assertions.assertEquals(1, pair.getKey().getRow());
         Assertions.assertEquals(4, pair.getValue().getRow());
     }

--- a/src/test/java/org/cqfn/astranaut/core/base/PositionTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/base/PositionTest.java
@@ -23,6 +23,7 @@
  */
 package org.cqfn.astranaut.core.base;
 
+import org.cqfn.astranaut.core.utils.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -42,5 +43,20 @@ class PositionTest {
         Assertions.assertTrue(third.compareTo(first) > 0);
         final Position alien = new DefaultPosition(another, 1, 1);
         Assertions.assertThrows(IllegalArgumentException.class, () -> first.compareTo(alien));
+    }
+
+    @Test
+    void testBounds() {
+        Assertions.assertThrows(IllegalArgumentException.class, Position::bounds);
+        final Source source = (start, end) -> "";
+        final Position[] list = {
+            new DefaultPosition(source, 2, 2),
+            new DefaultPosition(source, 1, 1),
+            new DefaultPosition(source, 4, 4),
+            new DefaultPosition(source, 3, 3),
+        };
+        final Pair<Position, Position> pair = Position.bounds(list);
+        Assertions.assertEquals(1, pair.getKey().getRow());
+        Assertions.assertEquals(4, pair.getValue().getRow());
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/utils/ParserTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/ParserTest.java
@@ -66,7 +66,7 @@ class ParserTest {
         Assertions.assertEquals("x", fragment.getCode());
         Assertions.assertEquals(
             ParserTest.TEST_FILE.concat(", 4.13-4.13"),
-            fragment.getPosition()
+            fragment.getPositionAsString()
         );
     }
 
@@ -117,7 +117,11 @@ class ParserTest {
         Assertions.assertEquals("printf(\"x\");", fragment.getCode());
         Assertions.assertEquals(
             ParserTest.TEST_FILE.concat(", 4.5-4.16"),
-            fragment.getPosition()
+            fragment.getPositionAsString()
+        );
+        Assertions.assertEquals(
+            ParserTest.TEST_FILE.concat(", 4.5-4.16"),
+            fragment.toString()
         );
         fragment = new DefaultFragment(
             first.getFragment().getBegin(),
@@ -126,7 +130,7 @@ class ParserTest {
         Assertions.assertEquals("{\n    printf(\"x\");\n}", fragment.getCode());
         Assertions.assertEquals(
             ParserTest.TEST_FILE.concat(", 3.13-5.1"),
-            fragment.getPosition()
+            fragment.getPositionAsString()
         );
         fragment = new DefaultFragment(
             last.getFragment().getEnd(),
@@ -143,8 +147,20 @@ class ParserTest {
         Assertions.assertEquals(3, tree.getRoot().getChildCount());
         Assertions.assertEquals(
             "1.1-1.1",
-            tree.getRoot().getChild(0).getFragment().getPosition()
+            tree.getRoot().getChild(0).getFragment().getPositionAsString()
         );
+    }
+
+    @Test
+    void fragmentAsString() {
+        final FileSource source = new FileSource(ParserTest.TEST_FILE);
+        Iterator<Char> iterator = source.iterator();
+        final Fragment first = iterator.next().getFragment();
+        Assertions.assertEquals(first.toString(), ParserTest.TEST_FILE.concat(", 1.1"));
+        final StringSource other = new StringSource("qwe");
+        iterator = other.iterator();
+        final Fragment second = iterator.next().getFragment();
+        Assertions.assertEquals(second.toString(), "1.1");
     }
 
     @Test

--- a/src/test/java/org/cqfn/astranaut/core/utils/ParserTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/ParserTest.java
@@ -23,6 +23,7 @@
  */
 package org.cqfn.astranaut.core.utils;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -174,15 +175,18 @@ class ParserTest {
     void charFragmentComparison() {
         final StringSource source = new StringSource("qwerty");
         final Iterator<Char> iterator = source.iterator();
-        final Char node = iterator.next();
-        final Fragment first = node.getFragment();
+        final Char alpha = iterator.next();
+        final Fragment first = alpha.getFragment();
         Assertions.assertTrue(first.equals(first));
         Assertions.assertFalse(first.equals(EmptyFragment.INSTANCE));
         Assertions.assertFalse(first.equals(DummyNode.INSTANCE));
         Assertions.assertNotEquals(0, first.hashCode());
         final Fragment second = source.iterator().next().getFragment();
         Assertions.assertEquals(first, second);
-        final Fragment third = iterator.next().getFragment();
+        final Char beta = iterator.next();
+        final Fragment third = beta.getFragment();
+        final Fragment compose = Fragment.fromNodes(Arrays.asList(alpha, beta));
+        Assertions.assertNotEquals(first, compose);
         Assertions.assertNotEquals(first, third);
     }
 }

--- a/src/test/java/org/cqfn/astranaut/core/utils/ParserTest.java
+++ b/src/test/java/org/cqfn/astranaut/core/utils/ParserTest.java
@@ -29,6 +29,8 @@ import java.util.NoSuchElementException;
 import org.cqfn.astranaut.core.base.Char;
 import org.cqfn.astranaut.core.base.DefaultFragment;
 import org.cqfn.astranaut.core.base.DefaultPosition;
+import org.cqfn.astranaut.core.base.DummyNode;
+import org.cqfn.astranaut.core.base.EmptyFragment;
 import org.cqfn.astranaut.core.base.Fragment;
 import org.cqfn.astranaut.core.base.Tree;
 import org.cqfn.astranaut.core.utils.parsing.FileSource;
@@ -166,5 +168,21 @@ class ParserTest {
             new DefaultPosition(source, 4, 4)
         );
         Assertions.assertEquals("\n\na\nb\nc\n", fragment.getCode());
+    }
+
+    @Test
+    void charFragmentComparison() {
+        final StringSource source = new StringSource("qwerty");
+        final Iterator<Char> iterator = source.iterator();
+        final Char node = iterator.next();
+        final Fragment first = node.getFragment();
+        Assertions.assertTrue(first.equals(first));
+        Assertions.assertFalse(first.equals(EmptyFragment.INSTANCE));
+        Assertions.assertFalse(first.equals(DummyNode.INSTANCE));
+        Assertions.assertNotEquals(0, first.hashCode());
+        final Fragment second = source.iterator().next().getFragment();
+        Assertions.assertEquals(first, second);
+        final Fragment third = iterator.next().getFragment();
+        Assertions.assertNotEquals(first, third);
     }
 }


### PR DESCRIPTION
Actually, we got the pattern from the differential tree and immediately applied it to the same code from which the differential tree was obtained. In some cases it is not applied.